### PR TITLE
feat: WhiskeySearchテーブルに基づくスキーマの更新と不要なDynamoDBテーブルの削除

### DIFF
--- a/infra/bin/infra.ts
+++ b/infra/bin/infra.ts
@@ -30,12 +30,10 @@ if (envConfig.domain) {
     // Hosted Zone IDは後でlookupできるので、一旦ドメイン名のみで作成
     hostedZoneId: '', // 空文字の場合はlookupを使用
     hostedZoneName: envConfig.domain,
-    crossRegionReferences: true, // クロスリージョン参照を有効化
     tags: {
       Project: 'WhiskeyApp',
       Environment: env
     }
-
   });
 }
 

--- a/infra/cdk.context.json
+++ b/infra/cdk.context.json
@@ -29,5 +29,9 @@
   "hosted-zone:account=401731371959:domainName=whiskeybar.site:region=ap-northeast-1": {
     "Id": "/hostedzone/Z01374187OVR4DE0RMHC",
     "Name": "whiskeybar.site."
-  }
+  },
+  "acknowledged-issue-numbers": [
+    34892,
+    34892
+  ]
 }

--- a/infra/lib/whiskey-infra-stack.ts
+++ b/infra/lib/whiskey-infra-stack.ts
@@ -146,19 +146,6 @@ export class WhiskeyInfraStack extends cdk.Stack {
     // DynamoDB Tables
     // ====================
     
-    // Whiskeysテーブル
-    const whiskeysTable = new dynamodb.Table(this, 'WhiskeysTable', {
-      tableName: `Whiskeys-${environment}`,
-      partitionKey: { name: 'id', type: dynamodb.AttributeType.STRING },
-      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
-      removalPolicy: environment === 'prod' ? cdk.RemovalPolicy.RETAIN : cdk.RemovalPolicy.DESTROY,
-    });
-
-    // GSI for name search
-    whiskeysTable.addGlobalSecondaryIndex({
-      indexName: 'NameIndex',
-      partitionKey: { name: 'name', type: dynamodb.AttributeType.STRING },
-    });
 
     // Reviewsテーブル
     const reviewsTable = new dynamodb.Table(this, 'ReviewsTable', {
@@ -335,7 +322,6 @@ export class WhiskeyInfraStack extends cdk.Stack {
     });
 
     // DynamoDB アクセス権限
-    whiskeysTable.grantReadWriteData(lambdaExecutionRole);
     reviewsTable.grantReadWriteData(lambdaExecutionRole);
     usersTable.grantReadWriteData(lambdaExecutionRole);
     whiskeySearchTable.grantReadWriteData(lambdaExecutionRole);
@@ -371,7 +357,7 @@ export class WhiskeyInfraStack extends cdk.Stack {
       memorySize: 256,
       role: lambdaExecutionRole,
       environment: {
-        WHISKEYS_TABLE: whiskeysTable.tableName,
+        WHISKEYS_TABLE: whiskeySearchTable.tableName,  // WhiskeySearchテーブルを使用
       },
     });
 
@@ -385,7 +371,7 @@ export class WhiskeyInfraStack extends cdk.Stack {
       memorySize: 256,
       role: lambdaExecutionRole,
       environment: {
-        WHISKEYS_TABLE: whiskeysTable.tableName,
+        WHISKEYS_TABLE: whiskeySearchTable.tableName,  // WhiskeySearchテーブルに統一
         REVIEWS_TABLE: reviewsTable.tableName, // ランキング機能のため追加
         WHISKEY_SEARCH_TABLE: whiskeySearchTable.tableName,
         ENVIRONMENT: environment,
@@ -403,7 +389,7 @@ export class WhiskeyInfraStack extends cdk.Stack {
       role: lambdaExecutionRole,
       environment: {
         REVIEWS_TABLE: reviewsTable.tableName,
-        WHISKEYS_TABLE: whiskeysTable.tableName,
+        WHISKEYS_TABLE: whiskeySearchTable.tableName,  // WhiskeySearchテーブルに統一
         COGNITO_USER_POOL_ID: userPool.userPoolId,
         ENVIRONMENT: environment,
       },
@@ -671,7 +657,7 @@ export class WhiskeyInfraStack extends cdk.Stack {
     }
 
     new cdk.CfnOutput(this, 'WhiskeysTableName', {
-      value: whiskeysTable.tableName,
+      value: whiskeySearchTable.tableName,  // WhiskeySearchテーブルに統一
       exportName: `whiskey-whiskeys-table-${environment}`,
     });
 

--- a/lambda/whiskeys-list/index.py
+++ b/lambda/whiskeys-list/index.py
@@ -50,8 +50,8 @@ def lambda_handler(event, context):
         for item in response['Items']:
             whiskey = {
                 'id': item['id'],
-                'name': item['name'],
-                'distillery': item['distillery'],
+                'name': item.get('name_en', item.get('name', '')),  # WhiskeySearchテーブルのスキーマに対応
+                'distillery': item.get('distillery_en', item.get('distillery', '')),  # WhiskeySearchテーブルのスキーマに対応
                 'created_at': item.get('created_at', ''),
                 'updated_at': item.get('updated_at', '')
             }


### PR DESCRIPTION
- cdk.context.jsonに問題番号を追加
- infra.tsからクロスリージョン参照の設定を削除
- whiskey-infra-stack.tsでWhiskeysテーブルの定義を削除し、WhiskeySearchテーブルを使用するように変更
- Lambda関数でWhiskeySearchテーブルのスキーマに対応するように修正