### PR TITLE
fix(analyze): モデル呼び出し後の予算ガードを戻し、文書の乖離を直す

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ This is a photo-first whiskey drink-log application built with a cost-optimized 
 - **Authentication**: AWS Cognito with Google OAuth（フロントは **ID トークン**を送信）
 - **Search**: Multi-language (English/Japanese) whiskey search
 - **Drink Log** 🆕: 写真を撮るだけの飲酒ログ（画像→S3、Bedrock で銘柄/飲み方判別、GPS + Google Places で店名推定、タイムライン）
-- **Data**: Rakuten API から Amazon Bedrock Nova Lite で抽出したウイスキーデータ
+- **Data**: Rakuten API から Amazon Bedrock（`jp.anthropic.claude-sonnet-4-6`）で抽出したウイスキーデータ
 - **Deployment**: CDK は手動（`infra/scripts/deploy.sh`）、CI はテスト + フロントデプロイ（`main` push、dev のみ）
 - **Cost Savings**: サーバーレス化 + 原子カウンタ/スロットリングで Bedrock・Places・画像ストレージの費用に上界
 
@@ -62,10 +62,10 @@ make api               # FastAPI アダプタ(:8000)
 
 ### Data Management
 ```bash
-# 🆕 Large-scale data processing with Bedrock Nova Lite
+# 🆕 Large-scale data processing with Bedrock (Claude Sonnet 4.6)
 python scripts/fetch_rakuten_names_only.py  # Fetch 3,037 products from Rakuten
-python scripts/extract_whiskey_names_nova_lite.py --input-file rakuten_product_names_*.json  # Extract with AI
-AWS_PROFILE=dev python scripts/insert_whiskeys_to_dynamodb.py nova_lite_extraction_results_*.json --target dev  # Insert to verified dev
+AWS_PROFILE=dev python scripts/extract_whiskey_names_claude_sonnet.py --input-file rakuten_product_names_*.json  # Extract with AI
+AWS_PROFILE=dev python scripts/insert_whiskeys_to_dynamodb.py scripts/catalog/extracted_expressions.json --target dev  # Insert to verified dev
 
 # Legacy method (archived)
 python scripts/fetch_whiskey_data.py --mode fetch --whiskeys 100
@@ -114,7 +114,7 @@ curl "https://api.dev.whiskeybar.site/api/whiskeys/search/?q=%E3%83%9C%E3%82%A6%
   - `AppState-dev`: 濫用/コスト防御の原子カウンタ（PK `pk`、TTL 有効）
   - ~~`Users-dev`~~: 廃止（プロフィールは Cognito 属性の読み取り専用表示）
   - ~~`Whiskeys-dev`~~: 廃止（`WhiskeySearch-dev` に統合）
-- **Bedrock**: 画像から銘柄/飲み方を判別（`jp.amazon.nova-2-lite-v1:0` 既定 / `jp.anthropic.claude-haiku-4-5` フォールバック、APAC 域内固定プロファイル、Converse API）
+- **Bedrock**: 画像から銘柄/飲み方を判別（`jp.anthropic.claude-sonnet-4-6` 既定 / Nova 2 Lite・Haiku 4.5 は切り戻し用、APAC 域内固定プロファイル、Converse API）。Nova/Haiku は銘柄名の音写が実用に耐えないため既定から外した（実写真27枚で検証）
 - **Cognito**: User authentication + Google OAuth（MAU従量）
 - **Route53**: DNS management with custom domains（クエリ従量）
 
@@ -247,7 +247,7 @@ WHISKEY_SEARCH_TABLE=WhiskeySearch-dev            # Search-optimized table
 DRINKLOGS_TABLE=DrinkLogs-dev                      # Drink logs table
 APP_STATE_TABLE=AppState-dev                       # Abuse/cost counters
 IMAGES_BUCKET=whiskey-images-dev-<account>         # Drink log images bucket
-BEDROCK_MODEL_ID=jp.amazon.nova-2-lite-v1:0        # Analyze model (allowlist gated)
+BEDROCK_MODEL_ID=jp.anthropic.claude-sonnet-4-6    # Analyze model (allowlist gated)
 ```
 
 ### Frontend (.env)
@@ -265,13 +265,13 @@ NUXT_PUBLIC_ENVIRONMENT=dev
 
 ### External Data Processing
 1. **Fetch**: `python scripts/fetch_rakuten_names_only.py`（楽天から商品名取得）
-2. **Extract**: `python scripts/extract_whiskey_names_nova_lite.py --input-file rakuten_*.json`（Bedrock Nova Lite で抽出）
+2. **Extract**: `AWS_PROFILE=dev python scripts/extract_whiskey_names_claude_sonnet.py --input-file rakuten_*.json`（Bedrock で構造化抽出。`--dry-run` で件数のみ確認可）
 3. **Seed/Insert**: `python scripts/local/seed_whiskeys.py --target dev --profile dev`（厳選シード）/ `AWS_PROFILE=dev python scripts/insert_whiskeys_to_dynamodb.py <input.json> --target dev`（大規模投入）
 4. **Verification**: DynamoDB のカウントと検索の動作確認（英語/日本語）
 
 ### Current Data Status
 - **Languages**: English and Japanese names（名前検索に特化、蒸留所検索は削除済み）
-- **Source**: 楽天市場API + Amazon Bedrock Nova Lite で抽出
+- **Source**: 楽天市場API + Amazon Bedrock で抽出
 - **Search Coverage**: Full text search across both languages
 
 ## AWS Profile Configuration

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
      │              │              │               │
 ┌────▼────┐  ┌──────▼─────┐  ┌─────▼─────┐  ┌──────▼──────┐
 │DynamoDB │  │  Cognito   │  │  Bedrock  │  │Google Places│
-│(各テーブル)│ │(認証/OAuth) │ │(Nova Lite) │  │  (店名推定)  │
+│(各テーブル)│ │(認証/OAuth) │ │(Sonnet 4.6)│  │  (店名推定)  │
 └─────────┘  └────────────┘  └───────────┘  └─────────────┘
 ```
 
@@ -29,7 +29,7 @@
 サーバーレス）。VPC は `natGateways: 0`、DynamoDB は pay-per-request。
 
 ### 主要機能
-- **多言語ウイスキー検索**: 楽天市場API + Amazon Bedrock Nova Lite で抽出したデータを英語/日本語で検索
+- **多言語ウイスキー検索**: 楽天市場API + Amazon Bedrock で抽出したデータを英語/日本語で検索
 - **フォトファースト飲酒ログ**: 写真アップロード → Bedrock で銘柄・飲み方を自動判別 →
   GPS + Google Places で店名候補を提案 → タイムラインで閲覧・編集・削除
 - **認証**: AWS Cognito（メール/パスワード + Google OAuth）
@@ -114,7 +114,7 @@ AWS_PROFILE=dev bash scripts/deploy.sh dev --base --diff-only # 無変更ドラ�
 
 ```bash
 python scripts/fetch_rakuten_names_only.py                                   # 楽天から商品名取得
-python scripts/extract_whiskey_names_nova_lite.py --input-file rakuten_*.json # Bedrock Nova Lite で抽出
+AWS_PROFILE=dev python scripts/extract_whiskey_names_claude_sonnet.py --input-file rakuten_*.json # Bedrock で構造化抽出
 python scripts/local/seed_whiskeys.py --target dev                           # 厳選シードを投入
 ```
 

--- a/docs/DRINK_LOG_AI_API.md
+++ b/docs/DRINK_LOG_AI_API.md
@@ -11,18 +11,35 @@
   "analysis_id": "ai-result:{user}:{uuid}",
   "candidates": [
     {
-      "brand_text": "表示名",
-      "name_ja": "日本語名",
-      "name_en": "English name",
+      "brand_text": "カリラ 12年",
+      "name_ja": "カリラ 12年",
+      "name_en": "Caol Ila 12 Year Old",
       "confidence": 0.9,
-      "whiskey_id": "完全一致または部分一致したID"
+      "match_source": "catalog",
+      "whiskey_id": "正規化後に完全一致したカタログのID（一致時のみ）"
     }
   ],
   "serving_style": "NEAT",
-  "model_id": "jp.amazon.nova-2-lite-v1:0",
-  "confidence": 0.9
+  "model_id": "jp.anthropic.claude-sonnet-4-6",
+  "confidence": 0.9,
+  "multiple_detected": false
 }
 ```
+
+`brand_text` は**常にモデルが読み取った銘柄名**で、カタログの名前で置き換えない。
+カタログはモデルの読みを上書きせず、一致したときに `whiskey_id` を付けるだけである
+（`山崎` を `山崎 12年` に格上げしない）。
+
+| `match_source` | 意味 |
+|---|---|
+| `catalog` | `normalize_text` による完全一致でカタログの ID を付与した |
+| `ai` | カタログに一致が無い。記録は成立し、`whiskey_id` は付かない |
+
+**部分一致・あいまい一致による ID 付与は行わない。** カタログが疎な状態で部分一致を許すと、
+`山崎` が `山崎 12年` に、シェリーオークが `ダブルカスク` に確定するといった誤りが起きる。
+
+`multiple_detected` は複数のボトルが検出されたことを示す。この場合フロントは候補を
+自動選択せず、ユーザーに選ばせる。`candidates` は最大5件。判別できない場合は空配列になる。
 
 画像はEXIF orientation適用、RGB化、メタデータ除去、JPEG再エンコードを行ってからBedrockへ送る。元画像バイトやEXIFはレスポンスに含めない。入力不正は400、所有権不一致は403、日次上限は429、月次グローバル遮断は503を返す。
 

--- a/frontend/composables/useDrinkLogBatch.ts
+++ b/frontend/composables/useDrinkLogBatch.ts
@@ -191,7 +191,11 @@ export const useDrinkLogBatch = (provided?: DrinkLogBatchDependencies) => {
   const saveItem = async (item: DrinkLogBatchItem, storeName: string, placeId: string) => {
     if (!item.analysisId || !item.brandText.trim()) {
       item.saveStatus = 'failed'
-      item.saveError = '銘柄名を入力してください。'
+      // Multiple bottles are deliberately left unselected, so the required
+      // action is picking one -- not typing a name.
+      item.saveError = item.candidates.length > 1 && item.selectedCandidateIndex === null
+        ? '検出された銘柄から1つ選んでください。'
+        : '銘柄名を入力してください。'
       return null
     }
 

--- a/frontend/tests/composables/useDrinkLogBatch.test.ts
+++ b/frontend/tests/composables/useDrinkLogBatch.test.ts
@@ -223,3 +223,43 @@ describe('useDrinkLogBatch', () => {
     expect(item.phase).toBe('ready')
   })
 })
+
+describe('useDrinkLogBatch save validation', () => {
+  it('asks the user to pick a bottle when several were detected', async () => {
+    const dependencies = makeDependencies()
+    dependencies.analyze.mockResolvedValue({
+      analysis_id: 'analysis-multi',
+      candidates: [
+        { brand_text: 'グレンリベット 12年', confidence: 0.95 },
+        { brand_text: 'ラガヴーリン 16年', confidence: 0.94 },
+      ],
+      model_id: 'test-model',
+      confidence: 0.95,
+      multiple_detected: true,
+    })
+    const batch = useDrinkLogBatch(dependencies)
+    await batch.processFiles([new File(['photo'], 'multi.jpg')])
+    const item = batch.items.value[0]!
+
+    await batch.savePending('', '')
+
+    expect(item.saveError).toBe('検出された銘柄から1つ選んでください。')
+  })
+
+  it('still asks for a brand name when nothing was detected', async () => {
+    const dependencies = makeDependencies()
+    dependencies.analyze.mockResolvedValue({
+      analysis_id: 'analysis-none',
+      candidates: [],
+      model_id: 'test-model',
+      confidence: 0,
+    })
+    const batch = useDrinkLogBatch(dependencies)
+    await batch.processFiles([new File(['photo'], 'none.jpg')])
+    const item = batch.items.value[0]!
+
+    await batch.savePending('', '')
+
+    expect(item.saveError).toBe('銘柄名を入力してください。')
+  })
+})

--- a/lambda/drink-log-analyze/index.py
+++ b/lambda/drink-log-analyze/index.py
@@ -491,6 +491,52 @@ def _get_master_snapshot(table: Any, table_name: str, logger: Any = None) -> dic
         return snapshot
 
 
+def _cached_master_snapshot(table_name: str) -> dict[str, Any] | None:
+    """Return the warm cache for this table, if any."""
+    cached = _MASTER_CACHE
+    if (
+        cached is not None
+        and cached["table_name"] == table_name
+        and cached["expires_at"] > time.monotonic()
+    ):
+        return cached
+    return None
+
+
+def _master_snapshot_within_budget(
+    table: Any,
+    table_name: str,
+    context: Any,
+    started: float,
+    logger: Any = None,
+) -> dict[str, Any]:
+    """Skip the catalog scan when there is not enough time left to afford it.
+
+    The scan runs after the model call and can take up to
+    MASTER_SNAPSHOT_MAX_PAGES sequential round trips on a cold container. With
+    no guard it can push the handler past the Lambda timeout, which surfaces as
+    a 502 instead of a graceful degradation. A warm cache costs nothing, so it
+    is always used; only an actual scan is gated.
+    """
+    cached = _cached_master_snapshot(table_name)
+    if cached is not None:
+        return cached
+    if _remaining_budget_ms(context, started) >= MIN_INVOKE_BUDGET_MS:
+        return _get_master_snapshot(table, table_name, logger)
+    if logger is not None:
+        logger.warning("Skipped master snapshot scan", reason="insufficient_budget")
+    # An incomplete snapshot makes every candidate fall back to match_source
+    # "ai": the record still saves, it just carries no catalog id.
+    return {
+        "table_name": table_name,
+        "expires_at": 0.0,
+        "items": (),
+        "complete": False,
+        "incomplete_reason": "insufficient_budget",
+        "page_count": 0,
+    }
+
+
 def _unique_records(records: list[Mapping[str, Any]]) -> list[Mapping[str, Any]]:
     unique: dict[str, Mapping[str, Any]] = {}
     for record in records:
@@ -604,9 +650,11 @@ def analyze_upload(
             "glass_type": "",
         }
 
-    snapshot = _get_master_snapshot(
+    snapshot = _master_snapshot_within_budget(
         dynamodb.Table(whiskey_table_name),
         whiskey_table_name,
+        context,
+        started,
         logger,
     )
     candidates = _build_candidates(snapshot, analysis)

--- a/tests/lambda/test_drink_log_analyze.py
+++ b/tests/lambda/test_drink_log_analyze.py
@@ -117,6 +117,23 @@ class Context:
         return self.remaining
 
 
+class SequencedContext(Context):
+    """Return a different remaining time on each call.
+
+    Lets a test give the model call enough budget while leaving the work that
+    follows it short, which is where the post-invoke guards matter.
+    """
+
+    def __init__(self, remaining_values):
+        super().__init__()
+        self.remaining_values = iter(remaining_values)
+        self.last = 0
+
+    def get_remaining_time_in_millis(self):
+        self.last = next(self.remaining_values, self.last)
+        return self.last
+
+
 class Bedrock:
     def __init__(self, texts):
         self.texts = list(texts)
@@ -891,3 +908,49 @@ def test_monthly_analysis_limit_is_a_503_circuit_breaker():
         )
 
     assert exc.value.status_code == 503
+
+
+def test_low_budget_skips_the_catalog_scan_and_still_returns_200(monkeypatch):
+    """The post-invoke scan must not be able to push the handler past timeout.
+
+    _get_master_snapshot can cost up to MASTER_SNAPSHOT_MAX_PAGES sequential
+    round trips on a cold container, and it runs after the model call. Without
+    a budget check it can exceed the Lambda timeout, which the client sees as a
+    502 rather than a record saved with no catalog id.
+    """
+    upload_uuid = "12345678-1234-4234-8234-123456789abc"
+    key = f"tmp/user-1/{upload_uuid}.png"
+    dynamodb = FakeDynamoDB()
+    bedrock = Bedrock([_model_json([_whiskey("カリラ 12年")])])
+    _wire_handler(monkeypatch, dynamodb, MemoryS3(key, _png_bytes()), bedrock)
+
+    # Enough budget for the model call, not enough for the scan afterwards.
+    response = analyze.lambda_handler(_event(key), SequencedContext([28_000, 28_000, 1_000]))
+
+    assert response["statusCode"] == 200
+    assert dynamodb.whiskeys.scan_calls == []
+    body = json.loads(response["body"])
+    assert [candidate["match_source"] for candidate in body["candidates"]] == ["ai"]
+    assert "whiskey_id" not in body["candidates"][0]
+
+
+def test_warm_cache_is_used_even_when_the_budget_is_low(monkeypatch):
+    """A cached snapshot costs nothing, so a tight budget must not discard it."""
+    upload_uuid = "12345678-1234-4234-8234-123456789abc"
+    key = f"tmp/user-1/{upload_uuid}.png"
+    dynamodb = FakeDynamoDB()
+    analyze._MASTER_CACHE = _snapshot([CAOL_ILA_ITEM])
+    try:
+        bedrock = Bedrock([_model_json([_whiskey("カリラ 12年")])])
+        _wire_handler(monkeypatch, dynamodb, MemoryS3(key, _png_bytes()), bedrock)
+
+        response = analyze.lambda_handler(
+            _event(key), SequencedContext([28_000, 28_000, 1_000])
+        )
+    finally:
+        analyze._reset_master_cache()
+
+    assert response["statusCode"] == 200
+    assert dynamodb.whiskeys.scan_calls == []
+    body = json.loads(response["body"])
+    assert body["candidates"][0]["match_source"] == "catalog"


### PR DESCRIPTION
PR #21 のレビュー指摘のうち、未対応で残っていた3件。

## 1. 予算ガードの復活（本番でハードタイムアウトを起こしうる・最優先）

fuzzy shortlist を削除した際、**その手前にあった予算チェックも一緒に消えていた**。

`_get_master_snapshot` はコールドコンテナで最大20ページの逐次スキャンを行い、しかも
**モデル呼び出しの後**に走る。`HANDLER_BUDGET_MS` を 20s → 24s にしたことで呼び出し後の
余裕が **12秒 → 8秒** に減っており、Lambda の 28 秒を超えると **502** になる。
（正しい挙動は「カタログIDが付かないまま記録が保存される」）

`_master_snapshot_within_budget` を追加した。**温かいキャッシュはコストゼロなので常に使い、
実際にスキャンが必要な場合だけ予算で守る**。予算不足なら不完全なスナップショットを返し、
全候補が `match_source: "ai"` に落ちる。

**変異テストで実効性を確認済み** — ガードを外すとテストが落ちる。

## 2. 複数本検出時の誤ったエラーメッセージ

候補が2件以上あると自動選択しない仕様のため、一括保存で「銘柄名を入力してください。」が
出ていた。実際に必要な操作は選択なので「検出された銘柄から1つ選んでください。」に分けた。

## 3. 文書の乖離

- `docs/DRINK_LOG_AI_API.md`: レスポンス形が古い。`match_source` / `multiple_detected` を追記し、
  **「部分一致でIDを付けない」理由**を明記
- `CLAUDE.md` / `README.md`: 既定モデルの記述が Nova Lite のまま
- **`extract_whiskey_names_nova_lite.py` という存在しないスクリプトを案内していた**
  （実在するのは `_claude_sonnet.py`）。記載コマンドが全て実在することを確認した

## レビューポイント

### キャッシュを予算で捨てない設計にした点

素直に「予算不足ならスキップ」とすると、**温かいキャッシュがある場合まで捨ててしまう**。
キャッシュ参照はコストゼロなので、スキャンが必要なときだけガードする形にしている。

### 予算不足時の縮退が「記録は成立する」ことの確認

`whiskey_id` が付かないだけで、ユーザーの記録自体は保存される。502 を返すより望ましい。

## 検証

python **237** / infra **46** / frontend typecheck **0 errors** / vitest **104** — すべて緑。

dev にデプロイし、実写真8枚で再測定:

```
確定して正解 3/3 (100%) | 誤確定 0/8 (0%) | 正しい棄却 5/5 (100%) | 取りこぼし 0/3 (0%)
```

※ 測定の過程で、私が作った評価マニフェストの期待値が2件誤っていた
（ブナハーブン・グレンフィディックはカタログに実在するのに `null` と記載）。
実態に合わせて修正済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VVnopDDfgo4reLzp2p35bX