### PR TITLE
銘柄候補セレクトを廃し、店を写真ごとに選べるようにする

### DIFF
--- a/.agent-tasks/16-log-form-store-and-wording.md
+++ b/.agent-tasks/16-log-form-store-and-wording.md
@@ -1,0 +1,175 @@
+# Task 16: 銘柄候補セレクトの廃止 / 店を写真ごとに / 文言の刷新
+
+## 背景・スコープ
+実機利用のフィードバック3件。**フロントエンドのみ**（`frontend/` 配下）で対応する。
+`lambda/`・`infra/`・スキーマ・API 契約（リクエスト/レスポンス JSON の形）は一切変更禁止。
+`git diff` が `frontend/` 以外に触れていたら不合格（`.agent-tasks/` を除く）。
+
+対象ファイル（想定）:
+- `frontend/composables/useDrinkLogBatch.ts`
+- `frontend/pages/logs/new.vue`
+- `frontend/pages/logs/index.vue`
+- `frontend/pages/home.vue`
+- `frontend/pages/privacy.vue`
+- `frontend/tests/composables/useDrinkLogBatch.test.ts`
+- `frontend/tests/pages/logsNew.test.ts`
+- `frontend/tests/components/imageLightbox.test.ts`（alt 文言のみ）
+
+---
+
+## 変更1: AI 銘柄候補のセレクトボックスを廃止する
+
+### 現状の問題
+`new.vue` の確認カードにある `<select>`（`AIの銘柄候補`）は、実際には候補が1件しか返らない
+ことがほとんどで、選択肢は「候補を使わず手入力」＋候補1件だけになる。そのすぐ下に
+「銘柄名 *」の自由入力欄があり、手入力はそちらで完結するため、このセレクトは意味を持たない。
+
+### あるべき姿
+セレクトを削除し、候補数に応じて表示を出し分ける。
+
+- **候補0件**: 現行の注記をそのまま維持
+  「銘柄候補を特定できませんでした。下の銘柄名を手入力してください。」
+- **候補1件**: コントロールを置かない。`applyAnalysis` が既に `brandText` を埋めているので、
+  「銘柄名 *」入力欄の下に**読み取り結果の注記**を出すだけにする。文言:
+  `AIの読み取り: {brand_text}（確度 {confidence*100 の四捨五入}%・{match_source === 'catalog' ? 'カタログ一致' : 'AI読取'}）`
+- **候補2件以上**: `<select>` ではなく**チップ（ボタン）で選ばせる**。既存の「飲み方」ピル
+  （`SERVING_STYLES` の `rounded-full border px-3 py-1.5` なラベル群）と同じ視覚言語に揃える。
+  - 各チップのラベルは `{brand_text}（{確度}%）`。選択中はピルと同じ選択状態スタイル
+    （`border-amber-500 bg-amber-700 text-amber-100`）、非選択は（`border-stone-500 bg-stone-600 text-amber-300`）。
+  - `type="button"`。クリックで既存の `selectCandidate(item, index)` を呼ぶ。
+  - 見出しは `AIが検出した銘柄`。既存の警告注記
+    「複数のボトルを検出しました。記録する銘柄を選んでください。」は維持する。
+  - `item.saveStatus === 'saved'` のときは `disabled`。
+  - **選択解除の専用 UI は作らない** — 銘柄名欄を編集すれば `handleBrandInput` 経由で
+    `selectedCandidateIndex` が null になる（既存挙動）。この経路が壊れていないことをテストで担保する。
+
+### 状態の整理
+`candidateSelection: string` は `<select>` の v-model 専用フィールドなので、
+**`DrinkLogBatchItem` から完全に削除**する（`newItem` の初期値・`processItem` のリセット・
+`applyAnalysis` の代入・`new.vue` の `handleCandidateSelection`・テストの参照をすべて削除）。
+`selectedCandidateIndex` は保存ペイロードの `candidate_index` を決める本体なので**残す**。
+
+`handleCandidateSelection` は不要になるため削除。`selectCandidate` / `handleBrandInput` は残す。
+
+### 壊してはいけない契約
+- `buildDrinkLogPayload` は `candidateIndex === null` のとき `brand_text`、そうでなければ
+  `candidate_index` を送る。**この分岐と送信 JSON の形は変えない**。
+- 候補1件が自動選択される（`applyAnalysis` の既存挙動）ことで、ユーザーが何もしなければ
+  `candidate_index: 0` が送られ `brand_source` が `ai|matched` になる。**この挙動を維持**する。
+
+---
+
+## 変更2: 店（場所）を写真1枚ごとに選べるようにする
+
+### 現状の問題
+店は「全ての記録に共通の店」セクションでバッチ全体に1つだけ選ぶ形になっており、
+`savePending(storeName, placeId)` で全カードに同じ値が適用される。
+複数枚をまとめて登録できるのに、写真ごとに違う店を記録できない。
+
+### あるべき姿
+**店の状態をカード（＝1杯）ごとに持つ。** 位置情報の取得と店候補の検索は共通のまま。
+
+#### `useDrinkLogBatch.ts`
+- `DrinkLogBatchItem` に `storeName: string` と `placeId: string` を追加（初期値は空文字）。
+  `newItem` で初期化し、`processItem` の再処理リセットでは**クリアしない**
+  （再解析でユーザーが選んだ店を消さないため。他のユーザー入力と違い店は写真から導出されない）。
+  ※ ただし `processFiles` は `reset()` で items ごと作り直すので新規選択時は自然に空に戻る。
+- `saveItem(item)` / `retrySave(item)` / `savePending()` から `storeName` / `placeId` 引数を削除し、
+  `item.storeName` / `item.placeId` を使う。**呼び出し側の署名変更をテストにも反映**すること。
+- 保存ペイロードは従来どおり `buildDrinkLogPayload` に `storeName` / `placeId` を渡す。
+  **API 契約は不変**。
+
+#### `new.vue`
+- ページレベルの `storeName` / `selectedPlaceId` ref は削除する。`places` / `placeError` /
+  `placeNotice` / `findNearbyPlaces` / `searchNearbyPlaces` / EXIF 連携は**共通のまま維持**。
+  - `searchNearbyPlaces` 内の `selectedPlaceId.value = ''` は、**全 item の `placeId` を空にする**
+    処理へ置き換える（新しい候補集合に対して古い place_id が残るのを防ぐ）。
+    `storeName` は消さない（ユーザーが手入力した店名は候補の再検索で失われるべきでない）。
+- 共通セクションの見出しを `店を探す` に変更し、説明文を
+  「近くの店を検索して、写真ごとに店を選べます。」に更新。位置情報の同意文言（`disclosure`）と
+  「近くの店を探す」ボタン、`placeNotice` / `placeError` はそのまま残す。
+- **候補一覧（現在のラジオリスト）は共通セクションに「参照用の一覧」として残す**。
+  ラジオ入力は削除し、店名・住所・`<GoogleAttributions>` を表示するだけのリストにする
+  （Google の表示名を出す箇所には帰属表示が必要なため、一覧側で必ず帰属を描画する）。
+  見出しは `近くの店候補`。
+- 共通セクションに **「1杯目の店を全カードに適用」ボタン**を置く（`items` に ready なカードが
+  2件以上あるときのみ表示）。押すと1件目の `storeName` / `placeId` を他の全カードへコピーする。
+  `saveStatus === 'saved'` のカードは対象外。
+- **各確認カードに店の入力を追加**する（「ノート（任意）」の直前あたり）:
+  - `店（任意）` の `<select>`：`places` が空でなければ表示。
+    `<option value="">店を選ばない</option>` ＋ 各候補（ラベルは `display_name`）。
+    v-model は `item.placeId`、`:disabled="item.saveStatus === 'saved'"`。
+    id は `place-${item.id}` のように**カードごとに一意**にすること。
+  - 選択中の候補があれば、その `<GoogleAttributions :attributions="place.attributions" />` を
+    セレクトの直下に描画する。
+  - `記録に残す店名（任意）` のテキスト入力：v-model は `item.storeName`、`maxlength="200"`、
+    id は `store-name-${item.id}`。
+  - 注記「Googleの表示名は保存しません。選んだ店の place_id と、ここに入力した名前だけを保存します。」を
+    カード側へ移す（共通セクションからは削除）。
+- `handleSubmit` は `savePending()`、`handleSaveRetry(item)` は `retrySave(item)` を呼ぶ形に更新。
+
+### 壊してはいけない契約（**最重要**）
+- **GPS 座標（lat/lng）は保存もペイロード送信もしない**。EXIF/端末 GPS で得た座標は
+  Places 検索に渡した直後に破棄する現行実装を維持すること。
+  `frontend/tests/pages/logsNew.test.ts` の
+  「保存呼び出しの引数に緯度経度が含まれない」旨のテストは、**新しい署名に合わせて書き換えたうえで
+  必ず残す**（`item.storeName` / `item.placeId` にも座標が入らないことを検証する形にする）。
+- 店名はユーザー入力テキスト、`place_id` は場所参照、という役割分担は不変。
+  **Google の `display_name` を `storeName` に自動代入してはならない**（ポリシー要件）。
+
+---
+
+## 変更3: 文言の刷新（「飲酒〜」を「テイスティング記録」系へ）
+
+「フォトファースト飲酒ログ」「飲酒ログ」「飲酒タイムライン」が不自然なので置き換える。
+**採用する語彙は以下で確定済み。勝手に別案を作らないこと。**
+
+| 箇所 | 旧 | 新 |
+|---|---|---|
+| `pages/home.vue:10` 上部ラベル | フォトファースト飲酒ログ | 写真ではじめるテイスティング記録 |
+| `pages/logs/new.vue` 上部ラベル | フォトファースト飲酒ログ | 写真ではじめるテイスティング記録 |
+| `pages/logs/index.vue` h1 | 飲酒タイムライン | テイスティング履歴 |
+| `pages/privacy.vue:25` | 保存した飲酒ログ画像 | 保存したテイスティング記録の画像 |
+| `pages/logs/new.vue` の画像 alt / lightbox alt | `{n}杯目の飲酒記録写真` | `{n}杯目のテイスティング写真` |
+
+- `pages/terms.vue:13` の「飲酒体験」「飲酒は法令を守り」は**変更しない**
+  （法務的な文脈で「飲酒」が適切なため）。
+- 上表以外の場所に新たな言い換えを持ち込まないこと。`飲み方` `一杯` `記録` 等の既存語は維持。
+- alt 文言を変えたテストの期待値（`tests/pages/logsNew.test.ts` / `tests/components/imageLightbox.test.ts`）も
+  合わせて更新する。
+
+---
+
+## テスト（vitest, `frontend/tests/`）
+既存テストを新しい署名・DOM に追従させたうえで、**次を新規に追加**すること。
+
+`tests/composables/useDrinkLogBatch.test.ts`:
+- `savePending()` が引数なしで、各 item の `storeName` / `placeId` を**それぞれの**保存ペイロードに
+  載せること（2件の item に別々の店を設定し、`createLog` が別々の `store` を受け取るのを検証）。
+- `storeName` も `placeId` も空の item は、ペイロードに `store` キー自体が現れないこと
+  （`buildDrinkLogPayload` の既存挙動）。
+- `DrinkLogBatchItem` に `candidateSelection` が存在しないこと（型・初期値の回帰防止）。
+
+`tests/pages/logsNew.test.ts`:
+- 候補1件のとき `<select>` が描画されず、銘柄名入力が候補で埋まっていること。
+- 候補2件以上のとき候補チップが2つ描画され、2つ目をクリックすると `brandText` がその候補になること。
+- 候補0件のとき既存の注記が出ること。
+- カードごとの店セレクト／店名入力が item の状態を更新すること。
+- 「1杯目の店を全カードに適用」で2件目の item に1件目の店がコピーされること。
+- 保存呼び出しに緯度経度が混入しないこと（前掲の必須テスト）。
+
+---
+
+## 受入条件
+- `cd frontend && npm ci && npm run lint && npm run typecheck && npx vitest run && npm run generate` が全て成功。
+  （**`npm test` は watch モードなので使わない。必ず `npx vitest run`**）
+- `git diff` は `frontend/` と `.agent-tasks/` のみ。`lambda/` `infra/` に一切触れていない。
+- 送信 JSON（`/api/drink-logs` の POST ボディ）の形が変わっていないこと。
+- 座標が保存ペイロード・item 状態・localStorage のいずれにも入らないこと。
+- 既存のスタイル踏襲（stone/amber Tailwind、日本語 UI 文言、`type="button"` の徹底）。
+
+## 実装メモ
+- 依存追加は不要。
+- `items.indexOf(item)` を使っている既存の番号表示はそのままでよい。
+- チップは `<button type="button">` で実装すること（`<label><input type="radio">` でも可だが、
+  飲み方ピルと視覚を揃えること）。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ This is a photo-first whiskey drink-log application built with a cost-optimized 
 - **Infrastructure**: AWS CDK (Lambda, API Gateway, S3, CloudFront, Cognito)
 - **Authentication**: AWS Cognito with Google OAuth（フロントは **ID トークン**を送信）
 - **Search**: Multi-language (English/Japanese) whiskey search
-- **Drink Log** 🆕: 写真を撮るだけの飲酒ログ（画像→S3、Bedrock で銘柄/飲み方判別、GPS + Google Places で店名推定、タイムライン）
+- **Drink Log** 🆕: 写真を撮るだけのテイスティング記録（画像→S3、Bedrock で銘柄/飲み方判別、GPS + Google Places で店名推定、履歴表示）
 - **Data**: Rakuten API から Amazon Bedrock（`jp.anthropic.claude-sonnet-4-6`）で抽出したウイスキーデータ
 - **Deployment**: CDK は手動（`infra/scripts/deploy.sh`）、CI はテスト + フロントデプロイ（`main` push、dev のみ）
 - **Cost Savings**: サーバーレス化 + 原子カウンタ/スロットリングで Bedrock・Places・画像ストレージの費用に上界
@@ -101,7 +101,7 @@ curl "https://api.dev.whiskeybar.site/api/whiskeys/search/?q=%E3%83%9C%E3%82%A6%
 - **VPC なし**: 未使用の VPC は削除済み。Lambda は常に VPC 外で実行（NAT Gateway/ALB/EC2/ECS/RDS は不使用）
 - **Lambda**: Serverless compute platform for API（実行時のみ課金）
   - `whiskey-list-dev` / `whiskey-search-dev`: 一覧・多言語検索（手動フィルタ）
-  - `drink-logs-dev`: 飲酒ログ CRUD・presigned URL・画像サニタイズ
+  - `drink-logs-dev`: テイスティング記録 CRUD・presigned URL・画像サニタイズ
   - `drink-log-analyze-dev`: Bedrock で銘柄/飲み方判別（Converse）
   - `drink-log-places-dev`: Google Places 検索・表示時解決
   - `drink-log-reconciler-dev`: 孤児画像/未収束レコードの日次収束
@@ -110,7 +110,7 @@ curl "https://api.dev.whiskeybar.site/api/whiskeys/search/?q=%E3%83%9C%E3%82%A6%
 - **CloudFront**: CDN for global content delivery（転送量従量）
 - **DynamoDB**: NoSQL database - Pay per request（アクセス従量）
   - `WhiskeySearch-dev`: Optimized search with English/Japanese names
-  - `DrinkLogs-dev`: 飲酒ログ（写真・銘柄・店・飲み方。GSI `UserDatetimeIndex`）
+  - `DrinkLogs-dev`: テイスティング記録（写真・銘柄・店・飲み方。GSI `UserDatetimeIndex`）
   - `AppState-dev`: 濫用/コスト防御の原子カウンタ（PK `pk`、TTL 有効）
   - ~~`Users-dev`~~: 廃止（プロフィールは Cognito 属性の読み取り専用表示）
   - ~~`Whiskeys-dev`~~: 廃止（`WhiskeySearch-dev` に統合）

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Whiskey Log
 
-**写真を撮るだけの飲酒ログ**に一本化したウイスキー記録アプリケーション。
-画像から銘柄と飲み方をAIが判別し、位置情報から店名候補を提案して、タイムラインで振り返れる。
+**写真を撮るだけのテイスティング記録**に一本化したウイスキー記録アプリケーション。
+画像から銘柄と飲み方をAIが判別し、位置情報から店名候補を提案して、履歴で振り返れる。
 銘柄の英語・日本語検索も備えた、費用最適化されたサーバーレス構成。
 
 ## 🏗️ アーキテクチャ
@@ -30,8 +30,8 @@
 
 ### 主要機能
 - **多言語ウイスキー検索**: 楽天市場API + Amazon Bedrock で抽出したデータを英語/日本語で検索
-- **フォトファースト飲酒ログ**: 写真アップロード → Bedrock で銘柄・飲み方を自動判別 →
-  GPS + Google Places で店名候補を提案 → タイムラインで閲覧・編集・削除
+- **写真ではじめるテイスティング記録**: 写真アップロード → Bedrock で銘柄・飲み方を自動判別 →
+  GPS + Google Places で店名候補を提案 → 履歴で閲覧・編集・削除
 - **認証**: AWS Cognito（メール/パスワード + Google OAuth）
 
 ### ドメイン構成
@@ -57,7 +57,7 @@
 | テーブル | 用途 | 主なキー / GSI |
 |----------|------|----------------|
 | `WhiskeySearch-{env}` | ウイスキー検索データ（英語/日本語名） | PK `id` / `NameIndex` |
-| `DrinkLogs-{env}` | 飲酒ログ（写真・銘柄・店・飲み方） | PK `id` / `UserDatetimeIndex`(user_id,datetime) |
+| `DrinkLogs-{env}` | テイスティング記録（写真・銘柄・店・飲み方） | PK `id` / `UserDatetimeIndex`(user_id,datetime) |
 | `AppState-{env}` | 濫用/コスト防御の原子カウンタ | PK `pk`（TTL 有効） |
 
 > `Users` テーブルは廃止（プロフィールは Cognito 属性の読み取り専用表示）。
@@ -79,7 +79,7 @@
 |------|------|
 | `whiskey-search-{env}` | 多言語検索（手動フィルタ + ページネーション） |
 | `whiskey-list-{env}` | ウイスキー一覧 |
-| `drink-logs-{env}` | 飲酒ログ CRUD・presigned URL・画像サニタイズ |
+| `drink-logs-{env}` | テイスティング記録 CRUD・presigned URL・画像サニタイズ |
 | `drink-log-analyze-{env}` | Bedrock で銘柄/飲み方判別（Converse） |
 | `drink-log-places-{env}` | Google Places 検索・表示時解決 |
 | `drink-log-reconciler-{env}` | 孤児画像・未収束レコードの日次収束 |
@@ -89,7 +89,7 @@
 - **AWS Cognito + Amplify**（SRP / Google OAuth code flow、`USER_PASSWORD_AUTH` 無効、ユーザー存在秘匿）
 - **トークン**: API Gateway の Cognito オーソライザー検証に合わせ、フロントは **ID トークン**を送信
   （`aud` == クライアントID、`token_use == 'id'` を多層で検証）
-- 公開読み取り（銘柄一覧・検索）は認証不要、飲酒ログは要認証
+- 公開読み取り（銘柄一覧・検索）は認証不要、テイスティング記録は要認証
 
 ## 🚀 デプロイ
 
@@ -149,7 +149,7 @@ NUXT_PUBLIC_ENVIRONMENT=dev
 
 ```
 whiskey/
-├── frontend/            # Nuxt.js SPA（pages/logs で飲酒ログ、composables で API クライアント）
+├── frontend/            # Nuxt.js SPA（pages/logs でテイスティング記録、composables で API クライアント）
 ├── lambda/              # Python Lambda 群
 │   ├── whiskeys-search/ whiskeys-list/
 │   ├── drink-logs/      # CRUD + reconciler.py

--- a/docs/LOCAL_DEV.md
+++ b/docs/LOCAL_DEV.md
@@ -29,9 +29,9 @@ curl --get --data-urlencode 'q=山崎' \
   http://localhost:8000/api/whiskeys/search
 ```
 
-## 飲酒ログをローカルで動かす
+## テイスティング記録をローカルで動かす
 
-飲酒ログも通常の起動手順で利用できます。
+テイスティング記録も通常の起動手順で利用できます。
 `docker compose up -d`を直接実行する場合は、MinIOのバケット作成が完了してから初期化してください。
 
 ```bash
@@ -93,7 +93,7 @@ make local-down
 
 `make api` は既定で `MOCK_AUTH=1` です。アダプタが固定ユーザー `local-test-user` の ID-token 相当 claims（`aud=local-client`、`token_use=id`）を API Gateway イベントへ注入します。Bearer token は不要です。
 
-飲酒ログ API は固定ユーザーの記録として利用できます。
+テイスティング記録 API は固定ユーザーの記録として利用できます。
 
 フロントエンドのローカル設定例です。
 

--- a/frontend/composables/useDrinkLogBatch.ts
+++ b/frontend/composables/useDrinkLogBatch.ts
@@ -24,11 +24,12 @@ export interface DrinkLogBatchItem {
   previewUrl: string
   analysisId: string
   candidates: DrinkLogCandidate[]
-  candidateSelection: string
   selectedCandidateIndex: number | null
   brandText: string
   servingStyle: ServingStyle | ''
   rating: number | null
+  storeName: string
+  placeId: string
   notes: string
   error: string
   saveStatus: BatchSaveStatus
@@ -72,6 +73,25 @@ const createLimiter = (limit: number) => {
   }
 }
 
+/**
+ * Copies one card's store onto the other cards. Saved cards are skipped: their
+ * record is already persisted, so mutating them would misrepresent what was stored.
+ */
+export const copyStoreToPendingItems = (items: DrinkLogBatchItem[], source: DrinkLogBatchItem) => {
+  items.forEach(item => {
+    if (item === source || item.saveStatus === 'saved') return
+    item.storeName = source.storeName
+    item.placeId = source.placeId
+  })
+}
+
+/** Drops place references that no longer belong to the current candidate set. */
+export const clearPendingItemPlaceIds = (items: DrinkLogBatchItem[]) => {
+  items.forEach(item => {
+    if (item.saveStatus !== 'saved') item.placeId = ''
+  })
+}
+
 const processingError = (cause: unknown) => {
   if (cause instanceof ImageTooLargeError) return '画像を3.5MB以下にできませんでした。別の画像を選択してください。'
   return normalizeDrinkLogError(cause, '画像の準備または解析に失敗しました。')
@@ -85,11 +105,12 @@ const newItem = (file: File, id: string): DrinkLogBatchItem => ({
   previewUrl: '',
   analysisId: '',
   candidates: [],
-  candidateSelection: '',
   selectedCandidateIndex: null,
   brandText: '',
   servingStyle: '',
   rating: null,
+  storeName: '',
+  placeId: '',
   notes: '',
   error: '',
   saveStatus: 'idle',
@@ -126,7 +147,6 @@ export const useDrinkLogBatch = (provided?: DrinkLogBatchDependencies) => {
     item.candidates = analysis.candidates || []
     if (item.candidates.length === 1) {
       item.selectedCandidateIndex = 0
-      item.candidateSelection = '0'
       item.brandText = item.candidates[0]?.brand_text || ''
     }
     if (analysis.serving_style && SERVING_STYLES.includes(analysis.serving_style as ServingStyle)) {
@@ -140,7 +160,6 @@ export const useDrinkLogBatch = (provided?: DrinkLogBatchDependencies) => {
     item.uploadProgress = 0
     item.analysisId = ''
     item.candidates = []
-    item.candidateSelection = ''
     item.selectedCandidateIndex = null
     item.brandText = ''
     item.servingStyle = ''
@@ -188,7 +207,7 @@ export const useDrinkLogBatch = (provided?: DrinkLogBatchDependencies) => {
     return { accepted: accepted.length, rejected: Math.max(0, files.length - accepted.length) }
   }
 
-  const saveItem = async (item: DrinkLogBatchItem, storeName: string, placeId: string) => {
+  const saveItem = async (item: DrinkLogBatchItem) => {
     if (!item.analysisId || !item.brandText.trim()) {
       item.saveStatus = 'failed'
       // Multiple bottles are deliberately left unselected, so the required
@@ -207,8 +226,8 @@ export const useDrinkLogBatch = (provided?: DrinkLogBatchDependencies) => {
         candidateIndex: item.selectedCandidateIndex,
         brandText: item.brandText,
         servingStyle: item.servingStyle,
-        storeName,
-        placeId,
+        storeName: item.storeName,
+        placeId: item.placeId,
         notes: item.notes,
         rating: item.rating,
       }))
@@ -222,18 +241,18 @@ export const useDrinkLogBatch = (provided?: DrinkLogBatchDependencies) => {
     }
   }
 
-  const retrySave = (item: DrinkLogBatchItem, storeName: string, placeId: string) => {
+  const retrySave = (item: DrinkLogBatchItem) => {
     if (item.saveStatus === 'saving' || item.saveStatus === 'saved') return Promise.resolve(item.createdLog)
     item.saveStatus = 'saving'
     item.saveError = ''
-    return saveWithLimit(() => saveItem(item, storeName, placeId))
+    return saveWithLimit(() => saveItem(item))
   }
 
-  const savePending = async (storeName: string, placeId: string) => {
+  const savePending = async () => {
     const pending = items.value.filter(item => (
       item.phase === 'ready' && ['idle', 'failed'].includes(item.saveStatus)
     ))
-    const results = await Promise.all(pending.map(item => retrySave(item, storeName, placeId)))
+    const results = await Promise.all(pending.map(item => retrySave(item)))
     return results.filter((log): log is DrinkLog => Boolean(log))
   }
 

--- a/frontend/pages/home.vue
+++ b/frontend/pages/home.vue
@@ -7,7 +7,7 @@ const { isAuthenticated } = useAuth()
 <template>
   <div class="mx-auto max-w-3xl px-4 py-10 text-center">
     <p class="mb-3 text-sm font-medium tracking-[0.2em] text-amber-400">
-      フォトファースト飲酒ログ
+      写真ではじめるテイスティング記録
     </p>
     <h1 class="mb-6 text-4xl font-bold text-amber-200 sm:text-5xl">
       今日の一杯を記録

--- a/frontend/pages/logs/index.vue
+++ b/frontend/pages/logs/index.vue
@@ -119,7 +119,7 @@ onBeforeUnmount(() => sentinelObserver?.disconnect())
     <header class="flex flex-wrap items-end justify-between gap-4">
       <div>
         <p class="text-sm font-medium text-amber-400">あなたの一杯</p>
-        <h1 class="mt-1 text-3xl font-semibold text-amber-200">飲酒タイムライン</h1>
+        <h1 class="mt-1 text-3xl font-semibold text-amber-200">テイスティング履歴</h1>
       </div>
       <NuxtLink to="/logs/new" class="rounded-md border border-amber-700 bg-amber-800 px-4 py-2 font-medium text-amber-100 hover:bg-amber-700">
         一杯を記録

--- a/frontend/pages/logs/new.vue
+++ b/frontend/pages/logs/new.vue
@@ -1,6 +1,12 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, reactive, ref } from 'vue'
-import { useDrinkLogBatch, MAX_DRINK_LOG_BATCH_SIZE, type DrinkLogBatchItem } from '~/composables/useDrinkLogBatch'
+import {
+  clearPendingItemPlaceIds,
+  copyStoreToPendingItems,
+  useDrinkLogBatch,
+  MAX_DRINK_LOG_BATCH_SIZE,
+  type DrinkLogBatchItem,
+} from '~/composables/useDrinkLogBatch'
 import { candidateIndexAfterBrandEdit, useDrinkLogs, type PlaceCandidate } from '~/composables/useDrinkLogs'
 import { useGeolocation } from '~/composables/useGeolocation'
 import { SERVING_STYLES, type ServingStyle } from '~/types/whiskey'
@@ -21,8 +27,6 @@ const {
 const { disclosure, requesting: requestingLocation, requestPosition } = useGeolocation()
 
 const places = ref<PlaceCandidate[]>([])
-const selectedPlaceId = ref('')
-const storeName = ref('')
 const pageError = ref('')
 const selectionNotice = ref('')
 const placeError = ref('')
@@ -50,7 +54,7 @@ const processingLabels: Record<DrinkLogBatchItem['phase'], string> = {
   failed: '失敗',
 }
 
-const selectedPlace = computed(() => places.value.find(place => place.place_id === selectedPlaceId.value) || null)
+const readyItems = computed(() => items.value.filter(item => item.phase === 'ready'))
 const canSave = computed(() => (
   items.value.some(item => item.phase === 'ready' && item.saveStatus !== 'saved')
   && !isProcessing.value
@@ -67,16 +71,7 @@ const selectCandidate = (item: DrinkLogBatchItem, index: number) => {
   const candidate = item.candidates[index]
   if (!candidate) return
   item.selectedCandidateIndex = index
-  item.candidateSelection = String(index)
   item.brandText = candidate.brand_text
-}
-
-const handleCandidateSelection = (item: DrinkLogBatchItem) => {
-  if (item.candidateSelection === '') {
-    item.selectedCandidateIndex = null
-    return
-  }
-  selectCandidate(item, Number(item.candidateSelection))
 }
 
 const handleBrandInput = (item: DrinkLogBatchItem) => {
@@ -87,8 +82,20 @@ const handleBrandInput = (item: DrinkLogBatchItem) => {
   )
   if (reconciledIndex === null) {
     item.selectedCandidateIndex = null
-    item.candidateSelection = ''
   }
+}
+
+const selectedPlaceFor = (item: DrinkLogBatchItem) => (
+  places.value.find(place => place.place_id === item.placeId) || null
+)
+const selectedPlaceAttributions = (item: DrinkLogBatchItem) => selectedPlaceFor(item)?.attributions || []
+
+const clearItemPlaceIds = () => clearPendingItemPlaceIds(items.value)
+
+const applyFirstStoreToAllCards = () => {
+  const firstItem = readyItems.value[0]
+  if (!firstItem) return
+  copyStoreToPendingItems(readyItems.value, firstItem)
 }
 
 const handleFileSelection = async (event: Event) => {
@@ -128,12 +135,12 @@ const searchNearbyPlaces = async (position: Coordinates, fromExif = false) => {
 
   try {
     places.value = await searchPlaces(position.lat, position.lng)
-    selectedPlaceId.value = ''
+    clearItemPlaceIds()
     if (fromExif) placeNotice.value = '写真の位置情報から近くの店を検索しました。'
     if (!places.value.length) placeError.value = '近くの店候補が見つかりませんでした。店名を手入力してください。'
   } catch (cause) {
     places.value = []
-    selectedPlaceId.value = ''
+    clearItemPlaceIds()
     placeError.value = errorMessage(cause, '近くの店を検索できませんでした。店名は手入力できます。')
   }
 }
@@ -144,7 +151,7 @@ const findNearbyPlaces = async () => {
   const position = await requestPosition()
   if (!position) {
     places.value = []
-    selectedPlaceId.value = ''
+    clearItemPlaceIds()
     placeError.value = '位置情報を取得できませんでした。店名を手入力して記録できます。'
     return
   }
@@ -169,12 +176,12 @@ const finishSave = async (created: Awaited<ReturnType<typeof savePending>>) => {
 
 const handleSubmit = async () => {
   pageError.value = ''
-  await finishSave(await savePending(storeName.value, selectedPlaceId.value))
+  await finishSave(await savePending())
 }
 
 const handleSaveRetry = async (item: DrinkLogBatchItem) => {
   pageError.value = ''
-  const created = await retrySave(item, storeName.value, selectedPlaceId.value)
+  const created = await retrySave(item)
   await finishSave(created ? [created] : [])
 }
 
@@ -189,7 +196,7 @@ const openLightbox = (src: string, alt: string) => {
 <template>
   <div class="mx-auto max-w-3xl px-4 sm:px-0">
     <div class="mb-6">
-      <p class="text-sm font-medium text-amber-400">フォトファースト飲酒ログ</p>
+      <p class="text-sm font-medium text-amber-400">写真ではじめるテイスティング記録</p>
       <h1 class="mt-1 text-3xl font-semibold text-amber-200">今日の一杯を記録</h1>
       <p class="mt-2 text-sm text-stone-300">写真1枚を1杯として、最大10枚をまとめて記録できます。AIの提案はすべて修正できます。</p>
     </div>
@@ -233,8 +240,8 @@ const openLightbox = (src: string, alt: string) => {
       <section v-if="items.length" class="space-y-4 rounded-lg border border-amber-700 bg-stone-800 p-5 shadow-lg">
         <div class="flex items-center justify-between gap-4">
           <div>
-            <h2 class="text-lg font-medium text-amber-200">全ての記録に共通の店</h2>
-            <p class="mt-1 text-xs text-stone-400">選択した店名と place_id を全カードに適用します。</p>
+            <h2 class="text-lg font-medium text-amber-200">店を探す</h2>
+            <p class="mt-1 text-xs text-stone-400">近くの店を検索して、写真ごとに店を選べます。</p>
           </div>
           <button type="button" :disabled="requestingLocation" class="rounded-md border border-amber-700 bg-stone-700 px-3 py-2 text-xs text-amber-100 hover:bg-stone-600 disabled:opacity-50" @click="findNearbyPlaces">
             {{ requestingLocation ? '位置情報を取得中…' : '近くの店を探す' }}
@@ -245,22 +252,17 @@ const openLightbox = (src: string, alt: string) => {
         <p v-if="placeError" role="status" class="text-sm text-amber-300">{{ placeError }}</p>
 
         <div v-if="places.length" class="space-y-2">
-          <label v-for="place in places" :key="place.place_id" class="block cursor-pointer rounded-md border p-3" :class="selectedPlaceId === place.place_id ? 'border-amber-500 bg-amber-950/50' : 'border-stone-600 bg-stone-700'">
-            <span class="flex gap-3">
-              <input v-model="selectedPlaceId" type="radio" name="place" :value="place.place_id" class="mt-1 border-stone-500 bg-stone-800 text-amber-600" />
-              <span class="min-w-0">
-                <span class="block font-medium text-amber-100">{{ place.display_name }}</span>
-                <span class="block text-xs text-stone-300">{{ place.formatted_address }}</span>
-                <GoogleAttributions :attributions="place.attributions" />
-              </span>
-            </span>
-          </label>
-          <button v-if="selectedPlace" type="button" class="text-xs text-stone-300 underline hover:text-amber-200" @click="selectedPlaceId = ''">店候補の選択を解除</button>
+          <h3 class="text-sm font-medium text-amber-200">近くの店候補</h3>
+          <div v-for="place in places" :key="place.place_id" class="rounded-md border border-stone-600 bg-stone-700 p-3">
+            <span class="block font-medium text-amber-100">{{ place.display_name }}</span>
+            <span class="block text-xs text-stone-300">{{ place.formatted_address }}</span>
+            <GoogleAttributions :attributions="place.attributions" />
+          </div>
         </div>
 
-        <label for="store-name" class="block text-sm text-amber-200">記録に残す店名（任意・自由入力）</label>
-        <input id="store-name" v-model="storeName" type="text" maxlength="200" placeholder="例: いつものバー" class="block w-full rounded-md border-amber-700 bg-stone-700 text-amber-100 placeholder:text-stone-400" />
-        <p class="text-xs text-stone-400">Googleの表示名は保存しません。選んだ店の place_id と、ここに入力した名前だけを保存します。</p>
+        <button v-if="readyItems.length >= 2" type="button" class="rounded-md border border-amber-700 bg-stone-700 px-3 py-2 text-xs text-amber-100 hover:bg-stone-600" @click="applyFirstStoreToAllCards">
+          最初の一杯の店を全カードに適用
+        </button>
       </section>
 
       <section v-for="item in items.filter(entry => entry.phase === 'ready')" :key="`card-${item.id}`" class="space-y-5 rounded-lg border border-amber-700 bg-stone-800 p-5 shadow-lg">
@@ -269,9 +271,9 @@ const openLightbox = (src: string, alt: string) => {
             type="button"
             aria-label="写真を拡大表示"
             class="h-28 w-28 shrink-0 cursor-zoom-in rounded-lg"
-            @click="openLightbox(item.previewUrl, `${items.indexOf(item) + 1}杯目の飲酒記録写真`)"
+            @click="openLightbox(item.previewUrl, `${items.indexOf(item) + 1}杯目のテイスティング写真`)"
           >
-            <img :src="item.previewUrl" :alt="`${items.indexOf(item) + 1}杯目の飲酒記録写真`" class="h-28 w-28 rounded-lg bg-stone-900 object-cover" />
+            <img :src="item.previewUrl" :alt="`${items.indexOf(item) + 1}杯目のテイスティング写真`" class="h-28 w-28 rounded-lg bg-stone-900 object-cover" />
           </button>
           <div>
             <h2 class="text-lg font-medium text-amber-200">{{ items.indexOf(item) + 1 }}杯目の確認</h2>
@@ -282,14 +284,24 @@ const openLightbox = (src: string, alt: string) => {
           </div>
         </div>
 
-        <div>
-          <label :for="`brand-candidate-${item.id}`" class="block text-sm font-medium text-amber-200">AIの銘柄候補</label>
-          <select :id="`brand-candidate-${item.id}`" v-model="item.candidateSelection" :disabled="item.saveStatus === 'saved'" class="mt-2 block w-full rounded-md border-amber-700 bg-stone-700 text-amber-100 disabled:opacity-50" @change="handleCandidateSelection(item)">
-            <option value="">候補を使わず手入力</option>
-            <option v-for="(candidate, candidateIndex) in item.candidates" :key="`${candidate.brand_text}-${candidateIndex}`" :value="String(candidateIndex)" class="bg-stone-700 text-amber-100">
-              {{ candidate.brand_text }}（確度 {{ Math.round(candidate.confidence * 100) }}%・{{ candidate.match_source === 'catalog' ? 'カタログ一致' : 'AI読取' }}）
-            </option>
-          </select>
+        <div v-if="item.candidates.length !== 1">
+          <template v-if="item.candidates.length > 1">
+            <p :id="`candidates-label-${item.id}`" class="block text-sm font-medium text-amber-200">AIが検出した銘柄</p>
+            <div role="group" :aria-labelledby="`candidates-label-${item.id}`" class="mt-2 flex flex-wrap gap-2">
+              <button
+                v-for="(candidate, candidateIndex) in item.candidates"
+                :key="`${candidate.brand_text}-${candidateIndex}`"
+                type="button"
+                :disabled="item.saveStatus === 'saved'"
+                :aria-pressed="item.selectedCandidateIndex === candidateIndex"
+                class="rounded-full border px-3 py-1.5 text-sm disabled:opacity-50"
+                :class="item.selectedCandidateIndex === candidateIndex ? 'border-amber-500 bg-amber-700 text-amber-100' : 'border-stone-500 bg-stone-600 text-amber-300'"
+                @click="selectCandidate(item, candidateIndex)"
+              >
+                {{ candidate.brand_text }}（{{ Math.round(candidate.confidence * 100) }}%）
+              </button>
+            </div>
+          </template>
           <p v-if="item.candidates.length > 1" class="mt-2 rounded-md border border-amber-700 bg-amber-950/60 p-3 text-sm text-amber-200">
             複数のボトルを検出しました。記録する銘柄を選んでください。
           </p>
@@ -301,6 +313,9 @@ const openLightbox = (src: string, alt: string) => {
         <div>
           <label :for="`brand-text-${item.id}`" class="block text-sm font-medium text-amber-200">銘柄名 *</label>
           <input :id="`brand-text-${item.id}`" v-model="item.brandText" :disabled="item.saveStatus === 'saved'" required type="text" maxlength="200" placeholder="例: アードベッグ 10年" class="mt-2 block w-full rounded-md border-amber-700 bg-stone-700 text-amber-100 placeholder:text-stone-400 disabled:opacity-50" @input="handleBrandInput(item)" />
+          <p v-if="item.candidates.length === 1 && item.candidates[0]" class="mt-1 text-xs text-stone-400">
+            AIの読み取り: {{ item.candidates[0].brand_text }}（確度 {{ Math.round(item.candidates[0].confidence * 100) }}%・{{ item.candidates[0].match_source === 'catalog' ? 'カタログ一致' : 'AI読取' }}）
+          </p>
           <p class="mt-1 text-xs text-stone-400">候補の文字を編集すると、手入力の銘柄として保存します。</p>
         </div>
 
@@ -323,6 +338,19 @@ const openLightbox = (src: string, alt: string) => {
             <button v-for="score in 5" :key="score" type="button" :disabled="item.saveStatus === 'saved'" :aria-label="`評価 ${score}`" class="p-1 text-2xl disabled:opacity-50" :class="item.rating && score <= item.rating ? 'text-amber-400' : 'text-stone-500'" @click="item.rating = score">★</button>
             <span class="ml-2 text-sm text-amber-300">{{ item.rating ? `${item.rating} / 5` : '評価なし' }}</span>
           </div>
+        </div>
+
+        <div>
+          <label v-if="places.length" :for="`place-${item.id}`" class="block text-sm font-medium text-amber-200">店（任意）</label>
+          <select v-if="places.length" :id="`place-${item.id}`" v-model="item.placeId" :disabled="item.saveStatus === 'saved'" class="mt-2 block w-full rounded-md border-amber-700 bg-stone-700 text-amber-100 disabled:opacity-50">
+            <option value="">店を選ばない</option>
+            <option v-for="place in places" :key="place.place_id" :value="place.place_id" class="bg-stone-700 text-amber-100">{{ place.display_name }}</option>
+          </select>
+          <GoogleAttributions v-if="selectedPlaceFor(item)" :attributions="selectedPlaceAttributions(item)" />
+
+          <label :for="`store-name-${item.id}`" class="mt-4 block text-sm font-medium text-amber-200">記録に残す店名（任意）</label>
+          <input :id="`store-name-${item.id}`" v-model="item.storeName" :disabled="item.saveStatus === 'saved'" type="text" maxlength="200" placeholder="例: いつものバー" class="mt-2 block w-full rounded-md border-amber-700 bg-stone-700 text-amber-100 placeholder:text-stone-400 disabled:opacity-50" />
+          <p class="mt-1 text-xs text-stone-400">Googleの表示名は保存しません。選んだ店の place_id と、ここに入力した名前だけを保存します。</p>
         </div>
 
         <div>

--- a/frontend/pages/privacy.vue
+++ b/frontend/pages/privacy.vue
@@ -22,7 +22,7 @@ useHead({ title: 'プライバシーポリシー | Whiskey Log' })
       <section>
         <h2 class="text-xl font-medium text-amber-200">3. 画像の保存と一時保持</h2>
         <p class="mt-2">アップロード直後の生画像は、処理のためS3の<code class="rounded bg-stone-800 px-1.5 py-0.5 text-amber-200">tmp/</code>領域に一時保持され、2日後に失効処理の対象になります。物理削除は非同期で行われるため、失効時刻と実際の削除時刻は一致しない場合があります。</p>
-        <p class="mt-2">保存した飲酒ログ画像はS3の<code class="rounded bg-stone-800 px-1.5 py-0.5 text-amber-200">logs/</code>領域へプライベート保存し、認証・認可を確認したうえで期限付きのpresigned URLを発行して表示します。</p>
+        <p class="mt-2">保存したテイスティング記録の画像はS3の<code class="rounded bg-stone-800 px-1.5 py-0.5 text-amber-200">logs/</code>領域へプライベート保存し、認証・認可を確認したうえで期限付きのpresigned URLを発行して表示します。</p>
       </section>
 
       <section>

--- a/frontend/tests/components/imageLightbox.test.ts
+++ b/frontend/tests/components/imageLightbox.test.ts
@@ -14,7 +14,7 @@ describe('ImageLightbox', () => {
       props: {
         open: false,
         src: 'blob:selected-image',
-        alt: '1杯目の飲酒記録写真',
+        alt: '1杯目のテイスティング写真',
       },
     })
 
@@ -24,9 +24,9 @@ describe('ImageLightbox', () => {
 
     const dialog = wrapper.get('[role="dialog"]')
     const image = dialog.get('img')
-    expect(dialog.attributes('aria-label')).toBe('1杯目の飲酒記録写真')
+    expect(dialog.attributes('aria-label')).toBe('1杯目のテイスティング写真')
     expect(image.attributes('src')).toBe('blob:selected-image')
-    expect(image.attributes('alt')).toBe('1杯目の飲酒記録写真')
+    expect(image.attributes('alt')).toBe('1杯目のテイスティング写真')
 
     wrapper.unmount()
   })

--- a/frontend/tests/composables/useDrinkLogBatch.test.ts
+++ b/frontend/tests/composables/useDrinkLogBatch.test.ts
@@ -1,5 +1,11 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { useDrinkLogBatch, type DrinkLogBatchDependencies } from '~/composables/useDrinkLogBatch'
+import { beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest'
+import {
+  clearPendingItemPlaceIds,
+  copyStoreToPendingItems,
+  useDrinkLogBatch,
+  type DrinkLogBatchDependencies,
+  type DrinkLogBatchItem,
+} from '~/composables/useDrinkLogBatch'
 import type { CreateDrinkLogPayload, DrinkLog, DrinkLogAnalysis } from '~/composables/useDrinkLogs'
 
 const makeLog = (index: number): DrinkLog => ({
@@ -46,7 +52,11 @@ describe('useDrinkLogBatch', () => {
     const files = Array.from({ length: 4 }, (_, index) => new File(['photo'], `${index}.jpg`, { type: 'image/jpeg' }))
 
     await batch.processFiles(files)
-    const created = await batch.savePending('共通店', 'place-1')
+    batch.items.value.forEach(item => {
+      item.storeName = '共通店'
+      item.placeId = 'place-1'
+    })
+    const created = await batch.savePending()
 
     expect(dependencies.resizeImage).toHaveBeenCalledTimes(4)
     expect(dependencies.getUploadUrl).toHaveBeenCalledTimes(4)
@@ -58,6 +68,35 @@ describe('useDrinkLogBatch', () => {
     })))
     expect(created).toHaveLength(4)
     expect(batch.allSaved.value).toBe(true)
+  })
+
+  it('saves each item with its own store name and place id', async () => {
+    const dependencies = makeDependencies()
+    const batch = useDrinkLogBatch(dependencies)
+    await batch.processFiles([
+      new File(['first'], 'first.jpg'),
+      new File(['second'], 'second.jpg'),
+    ])
+    Object.assign(batch.items.value[0]!, { storeName: '一軒目', placeId: 'place-first' })
+    Object.assign(batch.items.value[1]!, { storeName: '二軒目', placeId: 'place-second' })
+
+    await batch.savePending()
+
+    expect(dependencies.createLog).toHaveBeenCalledTimes(2)
+    expect(dependencies.createLog.mock.calls.map(([payload]) => payload.store)).toEqual([
+      { name: '一軒目', place_id: 'place-first' },
+      { name: '二軒目', place_id: 'place-second' },
+    ])
+  })
+
+  it('omits store from the payload when both item store fields are empty', async () => {
+    const dependencies = makeDependencies()
+    const batch = useDrinkLogBatch(dependencies)
+    await batch.processFiles([new File(['photo'], 'no-store.jpg')])
+
+    await batch.savePending()
+
+    expect(dependencies.createLog.mock.calls[0]?.[0]).not.toHaveProperty('store')
   })
 
   it('saves degraded analysis with a manually entered brand', async () => {
@@ -72,7 +111,7 @@ describe('useDrinkLogBatch', () => {
     await batch.processFiles([new File(['photo'], 'manual.jpg')])
     batch.items.value[0]!.brandText = '手入力銘柄'
 
-    await batch.savePending('', '')
+    await batch.savePending()
 
     expect(dependencies.createLog).toHaveBeenCalledWith({
       analysis_id: 'analysis-degraded',
@@ -99,7 +138,8 @@ describe('useDrinkLogBatch', () => {
     const item = batch.items.value[0]!
     expect(item.candidates).toHaveLength(2)
     expect(item.selectedCandidateIndex).toBeNull()
-    expect(item.candidateSelection).toBe('')
+    expect(item).not.toHaveProperty('candidateSelection')
+    expectTypeOf<'candidateSelection' extends keyof DrinkLogBatchItem ? true : false>().toEqualTypeOf<false>()
     expect(item.brandText).toBe('')
   })
 
@@ -138,7 +178,7 @@ describe('useDrinkLogBatch', () => {
     const files = Array.from({ length: 7 }, (_, index) => new File(['photo'], `${index}.jpg`))
 
     await batch.processFiles(files)
-    await batch.savePending('', '')
+    await batch.savePending()
 
     expect(processingMaximum).toBe(2)
     expect(saveMaximum).toBe(2)
@@ -156,13 +196,13 @@ describe('useDrinkLogBatch', () => {
       new File(['photo'], 'two.jpg'),
     ])
 
-    const firstAttempt = await batch.savePending('', '')
+    const firstAttempt = await batch.savePending()
 
     expect(firstAttempt).toHaveLength(1)
     expect(batch.items.value.map(item => item.saveStatus).sort()).toEqual(['failed', 'saved'])
     expect(batch.items.value.find(item => item.saveStatus === 'failed')?.saveError).toContain('本日の上限')
 
-    const retry = await batch.savePending('', '')
+    const retry = await batch.savePending()
 
     expect(retry).toHaveLength(1)
     expect(dependencies.createLog).toHaveBeenCalledTimes(3)
@@ -178,7 +218,7 @@ describe('useDrinkLogBatch', () => {
     const batch = useDrinkLogBatch(dependencies)
     await batch.processFiles([new File(['photo'], 'one.jpg')])
 
-    await Promise.all([batch.savePending('', ''), batch.savePending('', '')])
+    await Promise.all([batch.savePending(), batch.savePending()])
 
     expect(dependencies.createLog).toHaveBeenCalledTimes(1)
   })
@@ -192,7 +232,7 @@ describe('useDrinkLogBatch', () => {
 
     expect(batch.items.value.map(item => item.phase).sort()).toEqual(['failed', 'ready'])
     expect(batch.items.value.find(item => item.phase === 'failed')?.error).toBe('解析失敗')
-    await batch.savePending('', '')
+    await batch.savePending()
     expect(dependencies.createLog).toHaveBeenCalledTimes(1)
 
     const failed = batch.items.value.find(item => item.phase === 'failed')
@@ -214,6 +254,8 @@ describe('useDrinkLogBatch', () => {
     await batch.processFiles([new File(['p'], 'a.jpg', { type: 'image/jpeg' })])
     const item = batch.items.value[0]
     expect(item.phase).toBe('failed')
+    item.storeName = '再解析前に選んだ店'
+    item.placeId = 'place-before-retry'
 
     // Two synchronous retry clicks in the same frame must trigger only one reprocess.
     await Promise.all([batch.retryProcessing(item), batch.retryProcessing(item)])
@@ -221,6 +263,8 @@ describe('useDrinkLogBatch', () => {
     expect(dependencies.resizeImage).toHaveBeenCalledTimes(2) // 1 initial + 1 retry, not 3
     expect(analyzeCalls).toBe(2)
     expect(item.phase).toBe('ready')
+    expect(item.storeName).toBe('再解析前に選んだ店')
+    expect(item.placeId).toBe('place-before-retry')
   })
 })
 
@@ -241,7 +285,7 @@ describe('useDrinkLogBatch save validation', () => {
     await batch.processFiles([new File(['photo'], 'multi.jpg')])
     const item = batch.items.value[0]!
 
-    await batch.savePending('', '')
+    await batch.savePending()
 
     expect(item.saveError).toBe('検出された銘柄から1つ選んでください。')
   })
@@ -258,8 +302,49 @@ describe('useDrinkLogBatch save validation', () => {
     await batch.processFiles([new File(['photo'], 'none.jpg')])
     const item = batch.items.value[0]!
 
-    await batch.savePending('', '')
+    await batch.savePending()
 
     expect(item.saveError).toBe('銘柄名を入力してください。')
+  })
+})
+
+describe('per-card store helpers', () => {
+  const storeItem = (overrides: Partial<DrinkLogBatchItem> = {}) => ({
+    storeName: '',
+    placeId: '',
+    saveStatus: 'idle' as DrinkLogBatchItem['saveStatus'],
+    ...overrides,
+  }) as DrinkLogBatchItem
+
+  it('copies the source store onto the other pending cards', () => {
+    const source = storeItem({ storeName: 'いつものバー', placeId: 'place-1' })
+    const other = storeItem()
+    const items = [source, other]
+
+    copyStoreToPendingItems(items, source)
+
+    expect(other.storeName).toBe('いつものバー')
+    expect(other.placeId).toBe('place-1')
+  })
+
+  it('never overwrites a card that is already saved', () => {
+    const source = storeItem({ storeName: '2軒目', placeId: 'place-2' })
+    const saved = storeItem({ storeName: '1軒目', placeId: 'place-1', saveStatus: 'saved' })
+
+    copyStoreToPendingItems([source, saved], source)
+
+    expect(saved.storeName).toBe('1軒目')
+    expect(saved.placeId).toBe('place-1')
+  })
+
+  it('clears place ids on pending cards only, and keeps the typed store name', () => {
+    const pending = storeItem({ storeName: '手入力の店', placeId: 'stale-place' })
+    const saved = storeItem({ storeName: '保存済みの店', placeId: 'place-1', saveStatus: 'saved' })
+
+    clearPendingItemPlaceIds([pending, saved])
+
+    expect(pending.placeId).toBe('')
+    expect(pending.storeName).toBe('手入力の店')
+    expect(saved.placeId).toBe('place-1')
   })
 })

--- a/frontend/tests/pages/logsNew.test.ts
+++ b/frontend/tests/pages/logsNew.test.ts
@@ -5,7 +5,8 @@ import { flushPromises, mount } from '@vue/test-utils'
 import { computed, defineComponent, reactive, ref } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import ImageLightbox from '~/components/ImageLightbox.vue'
-import { buildDrinkLogPayload, candidateIndexAfterBrandEdit } from '~/composables/useDrinkLogs'
+import { copyStoreToPendingItems, type DrinkLogBatchItem } from '~/composables/useDrinkLogBatch'
+import { buildDrinkLogPayload, candidateIndexAfterBrandEdit, type DrinkLogCandidate, type PlaceCandidate } from '~/composables/useDrinkLogs'
 import LogsNewPage from '~/pages/logs/new.vue'
 import { SERVING_STYLES } from '~/types/whiskey'
 
@@ -86,19 +87,20 @@ const source = readFileSync(resolve(process.cwd(), 'pages/logs/new.vue'), 'utf8'
 const template = source.match(/<template>([\s\S]*)<\/template>/)?.[1]
 if (!template) throw new Error('logs/new.vue template not found')
 
-const batchItem = (candidates: unknown[] = []) => ({
-  id: 'photo-1',
+const batchItem = (candidates: DrinkLogCandidate[] = [], index = 0): DrinkLogBatchItem => ({
+  id: `photo-${index + 1}`,
   file: new File(['photo'], 'photo.jpg', { type: 'image/jpeg' }),
   phase: 'ready',
   uploadProgress: 100,
   previewUrl: 'blob:preview',
   analysisId: 'analysis-1',
   candidates,
-  candidateSelection: '',
-  selectedCandidateIndex: null,
-  brandText: '',
+  selectedCandidateIndex: candidates.length === 1 ? 0 : null,
+  brandText: candidates.length === 1 ? candidates[0]?.brand_text || '' : '',
   servingStyle: '',
   rating: null,
+  storeName: '',
+  placeId: '',
   notes: '',
   error: '',
   saveStatus: 'idle',
@@ -106,15 +108,48 @@ const batchItem = (candidates: unknown[] = []) => ({
   createdLog: null,
 })
 
-const renderLogPage = (options: { pageError?: string, placeError?: string, candidates?: unknown[] } = {}) => mount(defineComponent({
+const renderLogPage = (options: {
+  pageError?: string
+  placeError?: string
+  candidates?: DrinkLogCandidate[]
+  places?: PlaceCandidate[]
+  itemCount?: number
+} = {}) => mount(defineComponent({
   setup: () => {
     const lightbox = reactive({ open: false, src: '', alt: '' })
+    const items = ref(Array.from(
+      { length: options.itemCount || 1 },
+      (_, index) => batchItem(options.candidates || [], index),
+    ))
+    const places = ref(options.places || [])
+    const readyItems = computed(() => items.value.filter(item => item.phase === 'ready'))
+    const selectCandidate = (item: ReturnType<typeof batchItem>, index: number) => {
+      const candidate = item.candidates[index]
+      if (!candidate) return
+      item.selectedCandidateIndex = index
+      item.brandText = candidate.brand_text
+    }
+    const handleBrandInput = (item: ReturnType<typeof batchItem>) => {
+      item.selectedCandidateIndex = candidateIndexAfterBrandEdit(
+        item.candidates,
+        item.selectedCandidateIndex,
+        item.brandText,
+      )
+    }
+    const selectedPlaceFor = (item: ReturnType<typeof batchItem>) => (
+      places.value.find(place => place.place_id === item.placeId) || null
+    )
+    const selectedPlaceAttributions = (item: ReturnType<typeof batchItem>) => selectedPlaceFor(item)?.attributions || []
+    // Use the page's real helper rather than a copy, so drift is caught here.
+    const applyFirstStoreToAllCards = () => {
+      const firstItem = readyItems.value[0]
+      if (!firstItem) return
+      copyStoreToPendingItems(readyItems.value, firstItem)
+    }
     return {
-      items: ref([batchItem(options.candidates || [])]),
-      places: ref([]),
-      selectedPlaceId: ref(''),
-      selectedPlace: computed(() => null),
-      storeName: ref(''),
+      items,
+      places,
+      readyItems,
       pageError: ref(options.pageError || ''),
       selectionNotice: ref(''),
       placeError: ref(options.placeError || ''),
@@ -130,8 +165,11 @@ const renderLogPage = (options: { pageError?: string, placeError?: string, candi
       processingLabels: { queued: '処理中', resizing: '処理中', uploading: '処理中', analyzing: '処理中', ready: '解析完了', failed: '失敗' },
       handleFileSelection: vi.fn(),
       handleSubmit: vi.fn(),
-      handleCandidateSelection: vi.fn(),
-      handleBrandInput: vi.fn(),
+      selectCandidate,
+      handleBrandInput,
+      selectedPlaceFor,
+      selectedPlaceAttributions,
+      applyFirstStoreToAllCards,
       findNearbyPlaces: vi.fn(),
       handleProcessingRetry: vi.fn(),
       handleSaveRetry: vi.fn(),
@@ -212,7 +250,7 @@ describe('logs/new form behavior', () => {
   it('shows the shared manual store fallback when location permission is denied', () => {
     const wrapper = renderLogPage({ placeError: '位置情報を取得できませんでした。店名を手入力して記録できます。' })
     expect(wrapper.text()).toContain('店名を手入力して記録できます。')
-    expect(wrapper.find('#store-name').exists()).toBe(true)
+    expect(wrapper.find('input[id^="store-name-"]').exists()).toBe(true)
   })
 
   it.each([
@@ -224,13 +262,24 @@ describe('logs/new form behavior', () => {
     expect(wrapper.find('input[id^="brand-text-"]').exists()).toBe(true)
   })
 
-  it('asks for manual brand input when analysis returns no candidates', () => {
+  it('shows no candidate control and asks for manual brand input when analysis returns no candidates', () => {
     const wrapper = renderLogPage({ candidates: [] })
     expect(wrapper.text()).toContain('銘柄候補を特定できませんでした。')
     expect(wrapper.get('input[id^="brand-text-"]').attributes('required')).toBeDefined()
+    expect(wrapper.find('select[id^="brand-candidate-"]').exists()).toBe(false)
   })
 
-  it('shows catalog and AI candidate matching labels', () => {
+  it('shows one detected brand in the text field without rendering a candidate select', () => {
+    const wrapper = renderLogPage({
+      candidates: [{ brand_text: 'カリラ 12年', confidence: 0.904, match_source: 'catalog' }],
+    })
+
+    expect(wrapper.find('select[id^="brand-candidate-"]').exists()).toBe(false)
+    expect(wrapper.get<HTMLInputElement>('input[id^="brand-text-"]').element.value).toBe('カリラ 12年')
+    expect(wrapper.text()).toContain('AIの読み取り: カリラ 12年（確度 90%・カタログ一致）')
+  })
+
+  it('renders multiple candidates as chips and clears the selection when the brand is edited', async () => {
     const wrapper = renderLogPage({
       candidates: [
         { brand_text: 'カリラ 12年', confidence: 0.9, match_source: 'catalog' },
@@ -238,12 +287,72 @@ describe('logs/new form behavior', () => {
       ],
     })
 
-    const options = wrapper.findAll('option')
-    expect(options[1].text()).toContain('カタログ一致')
-    expect(options[1].text()).not.toContain('AI読取')
-    expect(options[2].text()).toContain('AI読取')
-    expect(options[2].text()).not.toContain('カタログ一致')
+    const chips = wrapper.findAll('button[aria-pressed]')
+    expect(chips).toHaveLength(2)
+    expect(chips[0]!.text()).toBe('カリラ 12年（90%）')
+    expect(chips[1]!.text()).toBe('山崎（80%）')
     expect(wrapper.text()).toContain('複数のボトルを検出しました。')
+
+    const secondChip = chips[1]!
+    const secondChipElement = secondChip.element as HTMLButtonElement
+    secondChipElement.click()
+    await wrapper.vm.$nextTick()
+    const brandInput = wrapper.get<HTMLInputElement>('input[id^="brand-text-"]')
+    expect(brandInput.element.value).toBe('山崎')
+    expect(secondChip.attributes('aria-pressed')).toBe('true')
+
+    brandInput.element.value = '山崎を手入力で修正'
+    brandInput.element.dispatchEvent(new Event('input', { bubbles: true }))
+    await wrapper.vm.$nextTick()
+    expect(secondChip.attributes('aria-pressed')).toBe('false')
+  })
+
+  it('shows AI-read matching text for a single non-catalog candidate', () => {
+    const wrapper = renderLogPage({
+      candidates: [{ brand_text: '山崎', confidence: 0.8, match_source: 'ai' }],
+    })
+
+    expect(wrapper.text()).toContain('AIの読み取り: 山崎（確度 80%・AI読取）')
+  })
+
+  it('updates the store selection and manual store name on each card', async () => {
+    const places: PlaceCandidate[] = [
+      { place_id: 'place-1', display_name: '候補店A', formatted_address: '東京都A', attributions: [] },
+      { place_id: 'place-2', display_name: '候補店B', formatted_address: '東京都B', attributions: [] },
+    ]
+    const wrapper = renderLogPage({ places })
+
+    const placeSelect = wrapper.get<HTMLSelectElement>('#place-photo-1')
+    placeSelect.element.value = 'place-2'
+    placeSelect.element.dispatchEvent(new Event('change', { bubbles: true }))
+    const storeInput = wrapper.get<HTMLInputElement>('#store-name-photo-1')
+    storeInput.element.value = '記録用の店名'
+    storeInput.element.dispatchEvent(new Event('input', { bubbles: true }))
+    await wrapper.vm.$nextTick()
+
+    const item = (wrapper.vm as unknown as { items: ReturnType<typeof batchItem>[] }).items[0]!
+    expect(item.placeId).toBe('place-2')
+    expect(item.storeName).toBe('記録用の店名')
+  })
+
+  it('copies the first card store fields to the other unsaved cards', async () => {
+    const places: PlaceCandidate[] = [
+      { place_id: 'place-1', display_name: '候補店A', formatted_address: '東京都A', attributions: [] },
+    ]
+    const wrapper = renderLogPage({ places, itemCount: 2 })
+    const placeSelect = wrapper.get<HTMLSelectElement>('#place-photo-1')
+    placeSelect.element.value = 'place-1'
+    placeSelect.element.dispatchEvent(new Event('change', { bubbles: true }))
+    const storeInput = wrapper.get<HTMLInputElement>('#store-name-photo-1')
+    storeInput.element.value = '一杯目の店'
+    storeInput.element.dispatchEvent(new Event('input', { bubbles: true }))
+    await wrapper.vm.$nextTick()
+
+    wrapper.findAll('button').find(button => button.text() === '最初の一杯の店を全カードに適用')!.element.click()
+    await wrapper.vm.$nextTick()
+
+    const items = (wrapper.vm as unknown as { items: ReturnType<typeof batchItem>[] }).items
+    expect(items[1]).toEqual(expect.objectContaining({ placeId: 'place-1', storeName: '一杯目の店' }))
   })
 
   it('opens the selected confirmation-card preview in the lightbox', async () => {
@@ -255,7 +364,7 @@ describe('logs/new form behavior', () => {
     const dialog = wrapper.get('[role="dialog"]')
     const image = dialog.get('img')
     expect(image.attributes('src')).toBe('blob:preview')
-    expect(image.attributes('alt')).toBe('1杯目の飲酒記録写真')
+    expect(image.attributes('alt')).toBe('1杯目のテイスティング写真')
     wrapper.unmount()
   })
 
@@ -308,9 +417,14 @@ describe('logs/new form behavior', () => {
     await flushPromises()
 
     expect(pageMocks.searchPlaces).toHaveBeenCalledWith(35.681236, 139.767125)
-    expect(pageMocks.savePending).toHaveBeenCalledWith('', '')
+    expect(pageMocks.savePending).toHaveBeenCalledWith()
     expect(pageMocks.savePending.mock.calls.flat()).not.toContain(35.681236)
     expect(pageMocks.savePending.mock.calls.flat()).not.toContain(139.767125)
+    const item = (wrapper.vm as unknown as { items: ReturnType<typeof batchItem>[] }).items[0]!
+    expect(item.storeName).toBe('')
+    expect(item.placeId).toBe('')
+    expect(item.storeName).not.toContain('35.681236')
+    expect(item.placeId).not.toContain('139.767125')
     wrapper.unmount()
   })
 })

--- a/infra/README.md
+++ b/infra/README.md
@@ -11,7 +11,7 @@ AWS CDK (TypeScript) を使用したウィスキーアプリケーションの�
 - **Lambda**: whiskeys-search/list、drink-logs、drink-log-analyze、drink-log-places、drink-log-reconciler（VPC 外実行、VPC なし）
 - **Cognito**: ユーザープール + アプリクライアント（Google OAuth）
 - **S3**:
-  - 飲酒ログ画像バケット（presigned URL、`tmp/` は2日ライフサイクル、CORS 設定済み）
+  - テイスティング記録の画像バケット（presigned URL、`tmp/` は2日ライフサイクル、CORS 設定済み）
   - Nuxt.js SPA 用 Web ホスティングバケット
 - **CloudFront**: SPA 配信用 CDN（ResponseHeadersPolicy / HSTS）
 - **DynamoDB**:


### PR DESCRIPTION
実機利用で挙がった3件の修正。フロントエンドのみ（`lambda/` `infra/` 変更なし、API 契約も不変）。

## 1. AI銘柄候補のセレクトボックスを廃止

候補は実質1件しか返らず、選択肢が「候補を使わず手入力」＋候補1件だけになっていた。
すぐ下に銘柄名の自由入力欄があるため、このセレクトは何も足していなかった。

- **候補1件**: コントロールを置かず、銘柄名欄の下に「AIの読み取り: ○○（確度92%・AI読取）」を注記
- **候補2件以上**: 飲み方ピルと同じチップで選択（`role="group"` + `aria-pressed`）
- **候補0件**: 従来の注記を維持

`candidateSelection` は select 専用の状態だったため型ごと削除。候補1件の自動選択
（`candidate_index:0` → `brand_source=ai|matched`）と、銘柄名編集による選択解除は従来どおり。

## 2. 店を写真1枚ごとに選べるように

複数枚をまとめて登録できるのに、店はバッチ共通で1つしか選べなかった。
`storeName`/`placeId` を `DrinkLogBatchItem` へ移し、各確認カードで店を選べるようにした。
位置情報の取得と候補検索は共通のまま、「最初の一杯の店を全カードに適用」で一括操作も残している。

- 保存済みカードは上書き・クリアの対象外（サーバー上の記録と表示が食い違うため）
- **座標を保存しない不変条件は変更なし**。Google の表示名も従来どおり永続化しない
- 表示名を出す箇所には従来どおり帰属表示（共通の参照一覧＋選択中の候補）

## 3. 文言

「フォトファースト飲酒ログ」「飲酒ログ」「飲酒タイムライン」が不自然だったため
「テイスティング記録」「テイスティング履歴」系へ統一。UI とドキュメント
（README / CLAUDE.md / docs/LOCAL_DEV.md / infra/README.md）を同時に更新。
`terms.vue` の「飲酒は法令を守り」は法務的文脈のため据え置き。

## 検証

- ローカル: `lint` / `typecheck` / `vitest`（19ファイル113テスト）/ `generate` 全通過
- 独立レビュー（codex-reviewer）: APPROVE。指摘のうち保存済みカードのクリア防止と
  ヘルパーの純関数化（テストがコピーではなく実コードを検証するように）を反映済み
- **dev 実機E2E**: 同一写真2枚を投入 → 旧セレクトの消滅・注記表示・カードごとの店選択・
  一括適用・独立性・保存を確認。DynamoDB 上で2件が別 `place_id` / 別店名、`brand_source=ai`、
  全レコードに座標属性なしを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FURbntamSSzLGDvU4rUVYG