### PR TITLE
fix(logs): 近くの店候補をタップで選べるようにする

### DIFF
--- a/.agent-tasks/18-selectable-nearby-places.md
+++ b/.agent-tasks/18-selectable-nearby-places.md
@@ -1,0 +1,114 @@
+# Task 18: 近くの店候補リストを選択可能にする（Issue #29）
+
+## 背景
+
+Issue #29:
+
+> 写真をアップロードしたとき、近くの店候補にリストで店名が表示されるが、表示されるだけで選択できるわけではない
+
+`frontend/pages/logs/new.vue` の共有セクション「店を探す」にある「近くの店候補」リスト
+（現状 254-261行付近）は `<div>` の読み取り専用リストで、クリックしても何も起きない。
+一方、各カードには `<select id="place-{item.id}">` があり、そちらでは選択できる。
+候補が並んでいるのにタップできないため、ユーザーは「選べない」と受け取る。
+
+## スコープ
+
+**`frontend/` のみ**。`lambda/` `infra/` は一切変更しない。API 契約・スキーマの変更も禁止。
+主な変更対象:
+- `frontend/pages/logs/new.vue`
+- `frontend/composables/useDrinkLogBatch.ts`（ヘルパー追加のみ）
+- `frontend/tests/pages/logsNew.test.ts` / `frontend/tests/composables/useDrinkLogBatch.test.ts`
+
+---
+
+## 変更1: 候補リストを選択可能なボタンにする
+
+「近くの店候補」の各項目を `<div>` から `<button type="button">` に変え、**押すと
+その店を未保存の全カードに適用する**（写真1枚のときは実質そのカードの選択になる）。
+
+- ボタンの中身（店名・住所・`<GoogleAttributions>`）は現状の表示内容を維持する。
+  `GoogleAttributions` がインタラクティブ要素を含む場合はボタンの外に出すこと
+  （ボタン入れ子は不正な HTML になる）。実装前に
+  `frontend/components/GoogleAttributions.vue` を確認して判断する。
+- **選択状態を視覚とアクセシビリティの両方で示す**: `:aria-pressed` に加え、選択中は
+  枠線・背景で区別できるスタイルを当てる（既存カードの選択チップ
+  `role="group"` + `aria-pressed` の実装に倣うこと）。
+- **選択判定**: 未保存カード（`saveStatus !== 'saved'`）が1枚以上あり、その**すべて**の
+  `placeId` がその候補と一致するときに選択中とみなす。
+- **再タップで選択解除**: 既に選択中の候補を押したら、未保存の全カードの `placeId` を空にする
+  （トグル）。「店を選ばない」に相当する操作を候補リスト側でも可能にする。
+- 保存済みカード（`saveStatus === 'saved'`）の `placeId` は**絶対に書き換えない**
+  （既存 `copyStoreToPendingItems` と同じ不変条件）。
+
+### 選択ロジックは composable の純関数として実装する
+
+`frontend/composables/useDrinkLogBatch.ts` に、既存の `copyStoreToPendingItems` /
+`clearPendingItemPlaceIds` と同じ流儀で純関数を追加し、`new.vue` からは import して使う
+（テストが実装をコピーせず本物を叩けるようにするため — 既存テストの
+`// Use the page's real helper rather than a copy` の意図を踏襲）。
+
+```ts
+/** True when every unsaved card already points at this place. */
+export const isPlaceSelectedForPendingItems = (items: DrinkLogBatchItem[], placeId: string): boolean
+
+/** Sets (or clears, when placeId is '') the place on every unsaved card. */
+export const setPlaceOnPendingItems = (items: DrinkLogBatchItem[], placeId: string): void
+```
+
+- `isPlaceSelectedForPendingItems` は未保存カードが0枚のとき `false` を返すこと
+  （空集合を「全一致」にすると、全部保存済みの画面で全候補が選択中に見える）。
+- `placeId` が空文字のときの `isPlaceSelectedForPendingItems` の扱いはテストで固定すること。
+
+## 変更2: 店名は自動入力しない（ポリシー厳守）
+
+**Google の `display_name` は絶対にフォームへ入れない・保存しない。**
+候補を押しても `storeName` は変更しない。永続化されるのは `place_id` とユーザーが自分で
+入力した `storeName` のみ、という既存の設計を維持する。
+
+候補リストの下に短い補足を置き、この挙動をユーザーに説明する。文言例:
+
+> 店を選ぶと写真すべてに適用されます。記録に残す店名は各カードで入力してください。
+
+（既存の 353行付近の説明文と重複した言い回しにならないよう調整してよい。）
+
+## 変更3: 見出し・説明文の整合
+
+- セクション説明「近くの店を検索して、写真ごとに店を選べます。」は、共有リストが
+  全カード適用になることと矛盾しないよう調整する（例:「近くの店を検索して選ぶと全カードに
+  適用されます。写真ごとの変更もできます。」）。
+- 「最初の一杯の店を全カードに適用」ボタンは**残す**。こちらは `placeId` に加えて
+  ユーザー入力の `storeName` もコピーする別機能であり、候補タップと役割が異なる。
+
+---
+
+## テスト
+
+### `frontend/tests/composables/useDrinkLogBatch.test.ts`
+
+- `setPlaceOnPendingItems` が未保存カードのみを更新し、`saveStatus === 'saved'` のカードを
+  変更しないこと
+- `setPlaceOnPendingItems(items, '')` が未保存カードの `placeId` を空にすること
+- `isPlaceSelectedForPendingItems` が「未保存カード全一致で true」「一部不一致で false」
+  「未保存カード0枚で false」を返すこと
+
+### `frontend/tests/pages/logsNew.test.ts`
+
+`renderLogPage` のテンプレート側スタブに新ヘルパーを配線した上で:
+
+- **候補ボタンのクリックで未保存の全カードの `placeId` が更新されること**（`itemCount: 2`）
+- **選択中の候補ボタンを再クリックすると `placeId` が空に戻ること**
+- **選択中の候補ボタンが `aria-pressed="true"`、非選択が `"false"` になること**
+- **保存済みカードの `placeId` が候補クリックで変わらないこと**
+- **候補クリックで `storeName` が変化しないこと**（Google 表示名を入れない回帰防止）
+- 既存の「per-card select で選べる」「最初の一杯の店を全カードに適用」テストが緑のままであること
+
+---
+
+## 受入条件
+
+- `cd frontend && npm ci && npm run lint && npm run typecheck && npx vitest run && npm run generate` が全通過
+  （**`npm test` は watch モードなので使わない**）
+- `git diff` が `frontend/` と `.agent-tasks/` のみ。`lambda/` `infra/` に一切触れていない
+- Google の `display_name` を `storeName` へ書き込むコードが存在しないこと（grep で確認）
+- 保存済みカードを書き換える経路が存在しないこと
+- 依存追加なし

--- a/frontend/composables/useDrinkLogBatch.ts
+++ b/frontend/composables/useDrinkLogBatch.ts
@@ -93,6 +93,19 @@ export const clearPendingItemPlaceIds = (items: DrinkLogBatchItem[]) => {
   })
 }
 
+/** True when every unsaved card already points at this place. */
+export const isPlaceSelectedForPendingItems = (items: DrinkLogBatchItem[], placeId: string): boolean => {
+  const pendingItems = items.filter(item => item.saveStatus !== 'saved')
+  return pendingItems.length > 0 && pendingItems.every(item => item.placeId === placeId)
+}
+
+/** Sets (or clears, when placeId is '') the place on every unsaved card. */
+export const setPlaceOnPendingItems = (items: DrinkLogBatchItem[], placeId: string): void => {
+  items.forEach(item => {
+    if (item.saveStatus !== 'saved') item.placeId = placeId
+  })
+}
+
 const processingError = (cause: unknown) => {
   if (cause instanceof ImageTooLargeError) return '画像を3.5MB以下にできませんでした。別の画像を選択してください。'
   return normalizeDrinkLogError(cause, '画像の準備または解析に失敗しました。')

--- a/frontend/pages/logs/new.vue
+++ b/frontend/pages/logs/new.vue
@@ -3,6 +3,8 @@ import { computed, onBeforeUnmount, reactive, ref } from 'vue'
 import {
   clearPendingItemPlaceIds,
   copyStoreToPendingItems,
+  isPlaceSelectedForPendingItems,
+  setPlaceOnPendingItems,
   useDrinkLogBatch,
   MAX_DRINK_LOG_BATCH_SIZE,
   type DrinkLogBatchItem,
@@ -91,6 +93,12 @@ const selectedPlaceFor = (item: DrinkLogBatchItem) => (
 const selectedPlaceAttributions = (item: DrinkLogBatchItem) => selectedPlaceFor(item)?.attributions || []
 
 const clearItemPlaceIds = () => clearPendingItemPlaceIds(items.value)
+
+const isSharedPlaceSelected = (placeId: string) => isPlaceSelectedForPendingItems(items.value, placeId)
+
+const toggleSharedPlace = (placeId: string) => {
+  setPlaceOnPendingItems(items.value, isSharedPlaceSelected(placeId) ? '' : placeId)
+}
 
 const applyFirstStoreToAllCards = () => {
   const firstItem = readyItems.value[0]
@@ -241,7 +249,7 @@ const openLightbox = (src: string, alt: string) => {
         <div class="flex items-center justify-between gap-4">
           <div>
             <h2 class="text-lg font-medium text-amber-200">店を探す</h2>
-            <p class="mt-1 text-xs text-stone-400">近くの店を検索して、写真ごとに店を選べます。</p>
+            <p class="mt-1 text-xs text-stone-400">近くの店を検索して選ぶと未保存の写真すべてに適用されます。写真ごとの変更もできます。</p>
           </div>
           <button type="button" :disabled="requestingLocation" class="rounded-md border border-amber-700 bg-stone-700 px-3 py-2 text-xs text-amber-100 hover:bg-stone-600 disabled:opacity-50" @click="findNearbyPlaces">
             {{ requestingLocation ? '位置情報を取得中…' : '近くの店を探す' }}
@@ -252,12 +260,23 @@ const openLightbox = (src: string, alt: string) => {
         <p v-if="placeError" role="status" class="text-sm text-amber-300">{{ placeError }}</p>
 
         <div v-if="places.length" class="space-y-2">
-          <h3 class="text-sm font-medium text-amber-200">近くの店候補</h3>
-          <div v-for="place in places" :key="place.place_id" class="rounded-md border border-stone-600 bg-stone-700 p-3">
-            <span class="block font-medium text-amber-100">{{ place.display_name }}</span>
-            <span class="block text-xs text-stone-300">{{ place.formatted_address }}</span>
-            <GoogleAttributions :attributions="place.attributions" />
+          <h3 id="nearby-places-label" class="text-sm font-medium text-amber-200">近くの店候補</h3>
+          <div role="group" aria-labelledby="nearby-places-label" class="space-y-2">
+            <div v-for="place in places" :key="place.place_id">
+              <button
+                type="button"
+                :aria-pressed="isSharedPlaceSelected(place.place_id)"
+                class="w-full rounded-md border p-3 text-left transition-colors"
+                :class="isSharedPlaceSelected(place.place_id) ? 'border-amber-500 bg-amber-950/60' : 'border-stone-600 bg-stone-700 hover:border-amber-700 hover:bg-stone-600'"
+                @click="toggleSharedPlace(place.place_id)"
+              >
+                <span class="block font-medium text-amber-100">{{ place.display_name }}</span>
+                <span class="block text-xs text-stone-300">{{ place.formatted_address }}</span>
+              </button>
+              <GoogleAttributions :attributions="place.attributions" />
+            </div>
           </div>
+          <p class="text-xs text-stone-400">店を選ぶと未保存の写真すべてに適用されます。記録に残す店名は各カードで入力してください。</p>
         </div>
 
         <button v-if="readyItems.length >= 2" type="button" class="rounded-md border border-amber-700 bg-stone-700 px-3 py-2 text-xs text-amber-100 hover:bg-stone-600" @click="applyFirstStoreToAllCards">

--- a/frontend/tests/composables/useDrinkLogBatch.test.ts
+++ b/frontend/tests/composables/useDrinkLogBatch.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest'
 import {
   clearPendingItemPlaceIds,
   copyStoreToPendingItems,
+  isPlaceSelectedForPendingItems,
+  setPlaceOnPendingItems,
   useDrinkLogBatch,
   type DrinkLogBatchDependencies,
   type DrinkLogBatchItem,
@@ -382,5 +384,51 @@ describe('per-card store helpers', () => {
     expect(pending.placeId).toBe('')
     expect(pending.storeName).toBe('手入力の店')
     expect(saved.placeId).toBe('place-1')
+  })
+
+  it('sets a place on pending cards without changing a saved card', () => {
+    const firstPending = storeItem({ placeId: 'place-old-1' })
+    const secondPending = storeItem({ placeId: 'place-old-2', saveStatus: 'failed' })
+    const saved = storeItem({ placeId: 'place-saved', saveStatus: 'saved' })
+
+    setPlaceOnPendingItems([firstPending, secondPending, saved], 'place-new')
+
+    expect(firstPending.placeId).toBe('place-new')
+    expect(secondPending.placeId).toBe('place-new')
+    expect(saved.placeId).toBe('place-saved')
+  })
+
+  it('clears the place on every pending card when passed an empty place id', () => {
+    const pending = storeItem({ placeId: 'place-1' })
+    const saved = storeItem({ placeId: 'place-saved', saveStatus: 'saved' })
+
+    setPlaceOnPendingItems([pending, saved], '')
+
+    expect(pending.placeId).toBe('')
+    expect(saved.placeId).toBe('place-saved')
+  })
+
+  it('reports a place selected only when every pending card matches it', () => {
+    const first = storeItem({ placeId: 'place-1' })
+    const second = storeItem({ placeId: 'place-1' })
+
+    expect(isPlaceSelectedForPendingItems([first, second], 'place-1')).toBe(true)
+
+    second.placeId = 'place-2'
+    expect(isPlaceSelectedForPendingItems([first, second], 'place-1')).toBe(false)
+  })
+
+  it('does not report a place selected when there are no pending cards', () => {
+    const saved = storeItem({ placeId: 'place-1', saveStatus: 'saved' })
+
+    expect(isPlaceSelectedForPendingItems([saved], 'place-1')).toBe(false)
+  })
+
+  it('treats an empty place id as selected when every pending card has no place', () => {
+    const emptyItems = [storeItem(), storeItem()]
+    const mixedItems = [storeItem(), storeItem({ placeId: 'place-1' })]
+
+    expect(isPlaceSelectedForPendingItems(emptyItems, '')).toBe(true)
+    expect(isPlaceSelectedForPendingItems(mixedItems, '')).toBe(false)
   })
 })

--- a/frontend/tests/pages/logsNew.test.ts
+++ b/frontend/tests/pages/logsNew.test.ts
@@ -5,7 +5,12 @@ import { flushPromises, mount } from '@vue/test-utils'
 import { computed, defineComponent, reactive, ref } from 'vue'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import ImageLightbox from '~/components/ImageLightbox.vue'
-import { copyStoreToPendingItems, type DrinkLogBatchItem } from '~/composables/useDrinkLogBatch'
+import {
+  copyStoreToPendingItems,
+  isPlaceSelectedForPendingItems,
+  setPlaceOnPendingItems,
+  type DrinkLogBatchItem,
+} from '~/composables/useDrinkLogBatch'
 import { buildDrinkLogPayload, candidateIndexAfterBrandEdit, type DrinkLogCandidate, type PlaceCandidate } from '~/composables/useDrinkLogs'
 import LogsNewPage from '~/pages/logs/new.vue'
 import { SERVING_STYLES } from '~/types/whiskey'
@@ -140,6 +145,11 @@ const renderLogPage = (options: {
       places.value.find(place => place.place_id === item.placeId) || null
     )
     const selectedPlaceAttributions = (item: ReturnType<typeof batchItem>) => selectedPlaceFor(item)?.attributions || []
+    // Use the page's real helpers rather than copies, so drift is caught here.
+    const isSharedPlaceSelected = (placeId: string) => isPlaceSelectedForPendingItems(items.value, placeId)
+    const toggleSharedPlace = (placeId: string) => {
+      setPlaceOnPendingItems(items.value, isSharedPlaceSelected(placeId) ? '' : placeId)
+    }
     // Use the page's real helper rather than a copy, so drift is caught here.
     const applyFirstStoreToAllCards = () => {
       const firstItem = readyItems.value[0]
@@ -169,6 +179,8 @@ const renderLogPage = (options: {
       handleBrandInput,
       selectedPlaceFor,
       selectedPlaceAttributions,
+      isSharedPlaceSelected,
+      toggleSharedPlace,
       applyFirstStoreToAllCards,
       findNearbyPlaces: vi.fn(),
       handleProcessingRetry: vi.fn(),
@@ -333,6 +345,95 @@ describe('logs/new form behavior', () => {
     const item = (wrapper.vm as unknown as { items: ReturnType<typeof batchItem>[] }).items[0]!
     expect(item.placeId).toBe('place-2')
     expect(item.storeName).toBe('記録用の店名')
+  })
+
+  it('applies a nearby-place candidate to every unsaved card', async () => {
+    const places: PlaceCandidate[] = [
+      { place_id: 'place-1', display_name: '候補店A', formatted_address: '東京都A', attributions: [] },
+    ]
+    const wrapper = renderLogPage({ places, itemCount: 2 })
+
+    wrapper.findAll('button').find(button => button.text().includes('候補店A'))!.element.click()
+    await wrapper.vm.$nextTick()
+
+    const items = (wrapper.vm as unknown as { items: ReturnType<typeof batchItem>[] }).items
+    expect(items.map(item => item.placeId)).toEqual(['place-1', 'place-1'])
+  })
+
+  it('clears every unsaved place id when the selected candidate is clicked again', async () => {
+    const places: PlaceCandidate[] = [
+      { place_id: 'place-1', display_name: '候補店A', formatted_address: '東京都A', attributions: [] },
+    ]
+    const wrapper = renderLogPage({ places, itemCount: 2 })
+    const candidateButton = wrapper.findAll('button').find(button => button.text().includes('候補店A'))!
+    const items = (wrapper.vm as unknown as { items: ReturnType<typeof batchItem>[] }).items
+
+    candidateButton.element.click()
+    await wrapper.vm.$nextTick()
+    // Assert the selection landed first: '' is also the initial value, so without
+    // this an inert button would satisfy the final assertion.
+    expect(items.map(item => item.placeId)).toEqual(['place-1', 'place-1'])
+
+    candidateButton.element.click()
+    await wrapper.vm.$nextTick()
+
+    expect(items.map(item => item.placeId)).toEqual(['', ''])
+  })
+
+  it('keeps the Google attributions outside the candidate button', () => {
+    const places: PlaceCandidate[] = [
+      { place_id: 'place-1', display_name: '候補店A', formatted_address: '東京都A', attributions: [] },
+    ]
+    const wrapper = renderLogPage({ places })
+
+    // GoogleAttributions renders links, so nesting it inside the button would be
+    // invalid interactive markup.
+    expect(wrapper.find('button google-attributions-stub').exists()).toBe(false)
+    expect(wrapper.find('google-attributions-stub').exists()).toBe(true)
+  })
+
+  it('exposes the shared candidate selection through aria-pressed', async () => {
+    const places: PlaceCandidate[] = [
+      { place_id: 'place-1', display_name: '候補店A', formatted_address: '東京都A', attributions: [] },
+      { place_id: 'place-2', display_name: '候補店B', formatted_address: '東京都B', attributions: [] },
+    ]
+    const wrapper = renderLogPage({ places, itemCount: 2 })
+    const placeButtons = wrapper.findAll('button').filter(button => button.text().includes('候補店'))
+
+    expect(placeButtons.map(button => button.attributes('aria-pressed'))).toEqual(['false', 'false'])
+    placeButtons[0]!.element.click()
+    await wrapper.vm.$nextTick()
+
+    expect(placeButtons.map(button => button.attributes('aria-pressed'))).toEqual(['true', 'false'])
+  })
+
+  it('does not change a saved card when a nearby-place candidate is clicked', async () => {
+    const places: PlaceCandidate[] = [
+      { place_id: 'place-new', display_name: '候補店A', formatted_address: '東京都A', attributions: [] },
+    ]
+    const wrapper = renderLogPage({ places, itemCount: 2 })
+    const items = (wrapper.vm as unknown as { items: ReturnType<typeof batchItem>[] }).items
+    Object.assign(items[1]!, { placeId: 'place-saved', saveStatus: 'saved' })
+
+    wrapper.findAll('button').find(button => button.text().includes('候補店A'))!.element.click()
+    await wrapper.vm.$nextTick()
+
+    expect(items[0]!.placeId).toBe('place-new')
+    expect(items[1]!.placeId).toBe('place-saved')
+  })
+
+  it('never copies a Google display name into the manual store name', async () => {
+    const places: PlaceCandidate[] = [
+      { place_id: 'place-1', display_name: 'Googleの候補店名', formatted_address: '東京都A', attributions: [] },
+    ]
+    const wrapper = renderLogPage({ places, itemCount: 2 })
+    const items = (wrapper.vm as unknown as { items: ReturnType<typeof batchItem>[] }).items
+    items[0]!.storeName = 'ユーザー入力の店名'
+
+    wrapper.findAll('button').find(button => button.text().includes('Googleの候補店名'))!.element.click()
+    await wrapper.vm.$nextTick()
+
+    expect(items.map(item => item.storeName)).toEqual(['ユーザー入力の店名', ''])
   })
 
   it('copies the first card store fields to the other unsaved cards', async () => {


### PR DESCRIPTION
## 背景

Issue #29 — 写真をアップロードすると「近くの店候補」に店名がリスト表示されるが、表示されるだけで選択できなかった。カードごとの `<select>` では選べるものの、目の前に並ぶ候補がタップできないため「選べない」と受け取られる。

## 変更

- 候補の各項目を `<button type="button">` のトグルに変更。押すと未保存の全カードに `place_id` を適用し、もう一度押すと解除する（写真1枚なら実質そのカードの選択）。
- 選択状態を `aria-pressed` と枠線・背景で提示。
- 選択ロジックは `useDrinkLogBatch.ts` の純関数 `isPlaceSelectedForPendingItems` / `setPlaceOnPendingItems` として実装。保存済みカードは書き換えない。
- 説明文を「未保存の写真すべてに適用されます」に統一。
- 「最初の一杯の店を全カードに適用」ボタンは維持（`storeName` もコピーする別機能のため）。

## プライバシー不変条件

Google の `display_name` は**フォームにも DB にも入れない**。候補タップで変わるのは `place_id` のみで、記録に残る店名はユーザーが各カードで入力したテキストに限る。帰属表示はボタンの外に配置し、インタラクティブ要素の入れ子を回避した。

## 検証

- `npm run lint` / `npm run typecheck` / `npx vitest run`（19ファイル・125テスト）/ `npm run generate` すべて通過
- `codex-reviewer` による独立レビュー: APPROVE（重大・重要の指摘なし）。軽微指摘のうち「トグルテストが no-op でも通る」「帰属の入れ子を守るテストが無い」「文言の揺れ」を反映済み
- diff は `frontend/` と `.agent-tasks/` のみ。`lambda/` `infra/` は未変更

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FURbntamSSzLGDvU4rUVYG