### PR TITLE
fix(logs): 店候補の選択状態を色以外でも示す

### DIFF
--- a/frontend/pages/logs/new.vue
+++ b/frontend/pages/logs/new.vue
@@ -270,8 +270,14 @@ const openLightbox = (src: string, alt: string) => {
                 :class="isSharedPlaceSelected(place.place_id) ? 'border-amber-500 bg-amber-950/60' : 'border-stone-600 bg-stone-700 hover:border-amber-700 hover:bg-stone-600'"
                 @click="toggleSharedPlace(place.place_id)"
               >
-                <span class="block font-medium text-amber-100">{{ place.display_name }}</span>
-                <span class="block text-xs text-stone-300">{{ place.formatted_address }}</span>
+                <span class="flex items-center gap-2">
+                  <!-- The mark carries the selected state on its own: colour alone is
+                       unreliable, and dark-mode extensions flatten it away entirely. -->
+                  <span aria-hidden="true" class="shrink-0 text-sm" :class="isSharedPlaceSelected(place.place_id) ? 'text-amber-300' : 'text-stone-500'">{{ isSharedPlaceSelected(place.place_id) ? '✓' : '○' }}</span>
+                  <span class="block font-medium text-amber-100">{{ place.display_name }}</span>
+                  <span v-if="isSharedPlaceSelected(place.place_id)" class="ml-auto shrink-0 rounded border border-amber-500 px-2 py-0.5 text-xs text-amber-200">選択中</span>
+                </span>
+                <span class="mt-1 block pl-6 text-xs text-stone-300">{{ place.formatted_address }}</span>
               </button>
               <GoogleAttributions :attributions="place.attributions" />
             </div>

--- a/frontend/tests/pages/logsNew.test.ts
+++ b/frontend/tests/pages/logsNew.test.ts
@@ -407,6 +407,25 @@ describe('logs/new form behavior', () => {
     expect(placeButtons.map(button => button.attributes('aria-pressed'))).toEqual(['true', 'false'])
   })
 
+  it('marks the selected candidate without relying on colour alone', async () => {
+    const places: PlaceCandidate[] = [
+      { place_id: 'place-1', display_name: '候補店A', formatted_address: '東京都A', attributions: [] },
+      { place_id: 'place-2', display_name: '候補店B', formatted_address: '東京都B', attributions: [] },
+    ]
+    const wrapper = renderLogPage({ places, itemCount: 2 })
+    const placeButtons = wrapper.findAll('button').filter(button => button.text().includes('候補店'))
+
+    expect(placeButtons.filter(button => button.text().includes('選択中'))).toHaveLength(0)
+    placeButtons[0]!.element.click()
+    await wrapper.vm.$nextTick()
+
+    // Dark-mode extensions flatten the selected background, so the state has to be
+    // readable from the text/mark rather than the colour.
+    expect(placeButtons[0]!.text()).toContain('選択中')
+    expect(placeButtons[0]!.text()).toContain('✓')
+    expect(placeButtons[1]!.text()).not.toContain('選択中')
+  })
+
   it('does not change a saved card when a nearby-place candidate is clicked', async () => {
     const places: PlaceCandidate[] = [
       { place_id: 'place-new', display_name: '候補店A', formatted_address: '東京都A', attributions: [] },


### PR DESCRIPTION
PR #30（Issue #29）の dev 実機確認で見つかった不足の追加修正。

## 問題

選択中の候補を枠線 `border-amber-500` と背景 `bg-amber-950/60` の色だけで示していた。dev のブラウザで確認したところ、Dark Reader 系のダークモード拡張が色を平坦化し、選択中と未選択の computed style が**完全に一致**していた（両方 `border: rgb(119,110,98)` / `background: rgb(24,26,27)`）。CSS ルール自体は正しく配信されているが、拡張の下では選択状態が視覚的に判別できない。

色単独で状態を示すのは色覚特性の観点でも不十分（WCAG 1.4.1 Use of Color）。

## 変更

- 候補ボタンの先頭にマーク（選択中 `✓` / 未選択 `○`）を追加
- 選択中は「選択中」バッジを右端に表示
- 既存の色の差は残す（拡張なしの環境ではそちらも効く）

## 検証

- `npm run lint` / `npm run typecheck` / `npx vitest run`（19ファイル・126テスト）/ `npm run generate` すべて通過
- 色に依存せず状態が読めることを検証するテストを追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FURbntamSSzLGDvU4rUVYG