### PR TITLE
feat(logs): ログ詳細の表示を整理し、日時を撮影日時にする

### DIFF
--- a/.agent-tasks/19-log-detail-display.md
+++ b/.agent-tasks/19-log-detail-display.md
@@ -1,0 +1,166 @@
+# Task 19: ログ詳細画面の表示変更（Issue #26）
+
+## 背景
+
+Issue #26 の4項目:
+
+1. 記録情報のトグルメニューがあるがこれを削除する
+2. 状態項目を削除する
+3. Google Maps の文言をリンカブルにして、クリックするとそのバーの情報が Google Map で見られるようにする。**緯度経度で指定するのではなく、店名で指定すること**
+4. 日時に表示する日付は作成日ではなく、**撮影日**にすること
+
+1〜3 はフロントのみ。**4 はバックエンドの変更を伴う** — 現状 `datetime` は Lambda が
+保存時刻で埋めており（`lambda/drink-logs/index.py:580` 付近 `"datetime": now`）、
+クライアントから送る経路が存在しない（`CREATE_FIELDS` に `datetime` が無い）。
+
+## スコープ
+
+`frontend/` `lambda/` `tests/` とドキュメント。**`infra/` は変更しない**
+（テーブル定義・GSI・IAM・環境変数はいずれも変更不要）。
+
+---
+
+## 変更1: 記録情報トグルの削除（フロント）
+
+`frontend/pages/logs/[id].vue` の `<details>…<summary>記録情報</summary>…</details>`
+ブロックを丸ごと削除する。記録ID・ユーザーID・作成日時・更新日時・AI解析JSON の表示も
+一緒に消える。`log.created_at` / `log.updated_at` / `log.ai` を参照する箇所が他に無いか
+grep で確認し、型定義（`DrinkLog`）自体は**変更しない**（API は引き続き返すため）。
+
+## 変更2: 「状態」項目の削除（フロント）
+
+同ファイルの `<dt>状態</dt><dd>{{ log.status }}</dd>` の `<div>` を削除する。
+残る `<dl>` は 日時 / 場所 / 飲み方 の3項目になる。`sm:grid-cols-2` のままでよい。
+
+## 変更3: 「Google Maps」を Google マップへのリンクにする
+
+`frontend/components/GoogleAttributions.vue` に**任意の `query` prop（string）**を追加する。
+
+- `query` が非空のとき、先頭の `Google Maps` テキストを `<a>` にする。
+  - `href`: `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(query)}`
+  - `target="_blank"` / `rel="noopener noreferrer"`
+  - **緯度経度は一切使わない**（そもそも保存していない）。店名のみをクエリにする。
+  - `translate="no"` と現在のクラスは維持する（Google のブランド表記要件）。
+- `query` が未指定/空のときは**現在どおりプレーンテキスト**にする（後方互換）。
+
+呼び出し側:
+- `frontend/components/DrinkLogStoreDisplay.vue`: 表示している店名 (`displayName`) を渡す。
+  ただし `場所登録済み` / `場所未登録` のプレースホルダのときは**渡さない**
+  （検索語として無意味なため）。
+- `frontend/pages/logs/new.vue` の近くの店候補リスト: `place.display_name` を渡す。
+
+**ポリシー注意**: これは表示中の Google 名を検索クエリとしてリンクに載せるだけで、
+`display_name` の**永続化ではない**。保存されるものは従来どおり `place_id` と
+ユーザー入力の店名のみ。この不変条件を壊す変更をしないこと。
+
+## 変更4: 日時を「撮影日時」にする（フロント + バックエンド）
+
+### 4-1. フロント: EXIF から撮影日時を読む
+
+新規 `frontend/utils/exifCapturedAt.ts`（`exifLocation.ts` と同じ流儀・同じ `exifr` 依存）:
+
+```ts
+/** 元ファイルの EXIF から撮影日時を読む。無い/不正なら null。 */
+export const readExifCapturedAt = (file: File): Promise<string | null>
+```
+
+- `exifr.parse(file, ['DateTimeOriginal', 'OffsetTimeOriginal', 'CreateDate'])` 等で取得する
+  （実際に使えるフィールド名は exifr の API を確認して決めること）。
+- **オフセットの扱いを明示的に決める**: EXIF の `DateTimeOriginal` はタイムゾーンを持たない。
+  `OffsetTimeOriginal` があればそれを採用し、無ければ**ブラウザのローカルタイムゾーン**として
+  解釈する（撮影端末＝閲覧端末という前提。サーバーが勝手に UTC とみなすより実態に近い）。
+- 返す文字列は**必ずオフセット付き RFC 3339**（`2026-08-01T21:30:00+09:00` 形式、または `Z`）。
+- 妥当性チェック: 2000-01-01 より前、または**現在時刻 + 5分**より後は `null` を返す
+  （壊れた EXIF がタイムラインの並び順を壊すのを防ぐ）。
+- 例外は握って `null`（`readExifGps` と同じ fail-safe）。
+
+`frontend/composables/useDrinkLogBatch.ts`:
+- `DrinkLogBatchItem` に `capturedAt: string | null` を追加する。
+- 処理フェーズ（`processItem`）で元ファイルから `readExifCapturedAt` を読み、item に保持する。
+  **縮小後の Blob ではなく元ファイルから読むこと**（canvas 再エンコードで EXIF は失われる）。
+- 保存時、`capturedAt` があれば作成ペイロードに `datetime` として載せる。
+  無ければ**フィールドごと省略**する（サーバーが保存時刻を入れる従来動作）。
+
+`frontend/composables/useDrinkLogs.ts`:
+- `CreateDrinkLogPayload` に `datetime?: string` を追加。
+- `DrinkLogFormValues` に `capturedAt?: string | null` を追加し、`buildDrinkLogPayload` が
+  非空のときだけ `datetime` を載せるようにする（既存の任意フィールドと同じ書き方）。
+
+`frontend/pages/logs/new.vue`:
+- 各カードの `記録日時: 今（保存時刻）` を、撮影日時が読めたときは
+  `撮影日時: {ローカル書式}`、読めなかったときは `記録日時: 保存時刻`（現行相当）に切り替える。
+  書式は `frontend/utils/drinkLogs.ts` の `formatLocalLogDate` / `formatLocalLogTime` を再利用する。
+
+`frontend/pages/logs/[id].vue`:
+- 「日時」の値は `log.datetime` のままでよい（サーバー側で撮影日時が入るようになるため）。
+  **ラベルだけ「日時」から「撮影日時」には変えない** — EXIF が無い記録では保存時刻が入るので、
+  一律に撮影日時と名乗るのは不正確になる。ラベルは「日時」を維持すること。
+
+### 4-2. バックエンド: 作成時に datetime を受け付ける
+
+`lambda/drink-logs/index.py`:
+
+- `CREATE_FIELDS` に `"datetime"` を追加する。**`UPDATE_FIELDS` には追加しない**
+  （撮影日時は作成時にのみ確定する。PUT で GSI のソートキーを動かせるようにしない）。
+- `validate_create_input` に検証を追加:
+  - 文字列であること
+  - **RFC 3339 かつオフセットまたは `Z` を持つこと。naive なタイムスタンプは 400 で拒否**
+    （サーバーはクライアントの TZ を知り得ない）
+  - 2000-01-01T00:00:00Z より前、または**現在時刻 + 5分**より後は 400
+  - 検証を通ったら **UTC に正規化して `YYYY-MM-DDTHH:MM:SS.sssZ` 形式**にする
+    （既存の `_rfc3339` / `_utc_now` と同じ字句順契約。GSI `UserDatetimeIndex` の
+    ソートキーであり、形式が揺れると字句順↔時系列順の一致が壊れる）
+- `_prepare_initial_record` が組み立てる pending レコードで、
+  **`datetime` は検証済みの値があればそれを、無ければ `now` を使う**。
+  **`created_at` / `updated_at` は常に実際の処理時刻（`now`）のまま**にすること
+  （撮影日時で上書きしない — 監査・収束処理の根拠が壊れる）。
+- 再開経路（`_finish_pending_create`）は既存 pending の `datetime` をそのまま使うこと
+  （再試行で日時が動かない）。
+
+### 4-3. ドキュメント
+
+- `API_REFERENCE.md` の `POST /api/drink-logs` に任意 `datetime` を追記
+  （オフセット必須・許容範囲・省略時はサーバー時刻）。
+- `swagger.yml` の作成リクエストスキーマに `datetime` を追加。レスポンスの
+  `datetime`（`Normalized RFC3339 UTC`）の記述は現状のままでよい。
+
+---
+
+## テスト
+
+### `tests/lambda/test_drink_logs.py`
+
+- 有効な `datetime`（`+09:00` 付き）を送ると、保存レコードの `datetime` が
+  **UTC 正規化された値**になり、`created_at` / `updated_at` は処理時刻のままであること
+- `datetime` 省略時は従来どおりサーバー時刻が入ること
+- **naive なタイムスタンプ（`2026-08-01T21:30:00`）は 400** であること
+- 未来（現在 + 1時間）と 1999 年は 400 であること
+- `PUT /api/drink-logs/{id}` に `datetime` を送ると**受理されない**こと
+  （`Field is not accepted` の 400）
+
+### `frontend/tests/`
+
+- `readExifCapturedAt`: オフセット付き EXIF、オフセット無し EXIF（ローカル TZ 解釈）、
+  EXIF 無し、壊れた値、範囲外（未来・2000年より前）の各ケース。
+  `exifr` はモックしてよい（実バイナリを置かないこと）。
+- `buildDrinkLogPayload` が `capturedAt` を `datetime` として載せ、null/未指定なら
+  **キーごと省略**すること
+- `logsDetail.test.ts`: 「記録情報」トグルと「状態」項目が**存在しない**こと
+- `GoogleAttributions`: `query` ありで `Google Maps` が期待 URL の `<a>`（`target="_blank"` +
+  `rel="noopener noreferrer"`）になること、`query` なしでリンクにならないこと、
+  クエリが URL エンコードされること
+- `DrinkLogStoreDisplay`: プレースホルダ表示（`場所登録済み` / `場所未登録`）のときに
+  `query` を渡さないこと
+
+---
+
+## 受入条件
+
+- `python -m pytest tests` が全通過
+- `cd frontend && npm ci && npm run lint && npm run typecheck && npx vitest run && npm run generate` が全通過
+  （**`npm test` は watch モードなので使わない**）
+- `cd infra && npm ci && npm run build && npx jest` が全通過（無変更のはずなので回帰確認）
+- `git diff` に `infra/` が含まれないこと
+- **`display_name` を永続化する経路が増えていないこと**（grep で確認）
+- 緯度経度を保存・送信・URL 化する経路が存在しないこと
+- 依存追加なし（`exifr` は既存依存）

--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -98,6 +98,13 @@ Resolves an owned log's optional Place ID for display without persisting a Googl
 
 Creates a drink log and moves the sanitized image from `tmp/` to `logs/`.
 
+The request may include `datetime` as an RFC 3339 timestamp with an explicit
+UTC offset or `Z` (for example, `2026-08-01T21:30:00+09:00`). It must not be
+earlier than `2000-01-01T00:00:00Z` or later than five minutes after the server's
+current time. The server normalizes an accepted value to UTC; when omitted, the
+server's processing time is used. `datetime` is create-only and is not accepted
+by `PUT /api/drink-logs/{id}`.
+
 ### `GET /api/drink-logs?limit=20&next_token=...&brand=...&store=...&place_id=...`
 
 Returns the authenticated user's timeline. `brand`, `store`, and `place_id` are optional filters.

--- a/frontend/components/DrinkLogStoreDisplay.vue
+++ b/frontend/components/DrinkLogStoreDisplay.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import type { DrinkLog, ResolvedPlace } from '~/composables/useDrinkLogs'
+import { STORE_NAME_PLACEHOLDERS } from '~/utils/drinkLogs'
 
 const props = defineProps<{
   log: DrinkLog
@@ -13,11 +14,18 @@ const displayName = computed(() => {
   if (isGoogleName.value && props.resolvedPlace?.display_name) return props.resolvedPlace.display_name
   return props.log.store.place_id ? '場所登録済み' : '場所未登録'
 })
+const googleMapsQuery = computed(() => STORE_NAME_PLACEHOLDERS.includes(displayName.value)
+  ? undefined
+  : displayName.value)
 </script>
 
 <template>
   <span class="block min-w-0">
     <span class="block truncate">{{ displayName }}</span>
-    <GoogleAttributions v-if="isGoogleName" :attributions="resolvedPlace?.attributions || []" />
+    <GoogleAttributions
+      v-if="isGoogleName"
+      :attributions="resolvedPlace?.attributions || []"
+      :query="googleMapsQuery"
+    />
   </span>
 </template>

--- a/frontend/components/GoogleAttributions.vue
+++ b/frontend/components/GoogleAttributions.vue
@@ -1,5 +1,11 @@
 <script setup lang="ts">
-defineProps<{ attributions: unknown[] }>()
+import { computed } from 'vue'
+
+const props = defineProps<{ attributions: unknown[], query?: string }>()
+
+const googleMapsUrl = computed(() => props.query?.trim()
+  ? `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(props.query)}`
+  : '')
 
 const attributionView = (attribution: unknown) => {
   if (typeof attribution === 'string') return { label: attribution, url: '' }
@@ -18,7 +24,15 @@ const attributionView = (attribution: unknown) => {
 
 <template>
   <span class="mt-1 block text-[11px] leading-relaxed text-stone-400">
-    <span translate="no" class="mr-2 whitespace-nowrap font-sans">Google Maps</span>
+    <a
+      v-if="googleMapsUrl"
+      :href="googleMapsUrl"
+      target="_blank"
+      rel="noopener noreferrer"
+      translate="no"
+      class="mr-2 whitespace-nowrap font-sans underline hover:text-amber-200"
+    >Google Maps</a>
+    <span v-else translate="no" class="mr-2 whitespace-nowrap font-sans">Google Maps</span>
     <template v-for="(attribution, index) in attributions" :key="index">
       <a
         v-if="attributionView(attribution).url"

--- a/frontend/composables/useDrinkLogBatch.ts
+++ b/frontend/composables/useDrinkLogBatch.ts
@@ -1,4 +1,5 @@
 import { computed, ref } from 'vue'
+import { ApiError } from '~/composables/useApi'
 import {
   buildDrinkLogPayload,
   normalizeDrinkLogError,
@@ -8,6 +9,7 @@ import {
   type DrinkLogCandidate,
 } from '~/composables/useDrinkLogs'
 import { SERVING_STYLES, type ServingStyle } from '~/types/whiskey'
+import { readExifCapturedAt } from '~/utils/exifCapturedAt'
 import { ImageTooLargeError, resizeImage } from '~/utils/imageResize'
 
 export const MAX_DRINK_LOG_BATCH_SIZE = 10
@@ -20,6 +22,7 @@ export type BatchSaveStatus = 'idle' | 'saving' | 'saved' | 'failed'
 export interface DrinkLogBatchItem {
   id: string
   file: File
+  capturedAt: string | null
   phase: BatchProcessingPhase
   uploadProgress: number
   previewUrl: string
@@ -39,6 +42,7 @@ export interface DrinkLogBatchItem {
 }
 
 export interface DrinkLogBatchDependencies {
+  readExifCapturedAt: typeof readExifCapturedAt
   resizeImage: typeof resizeImage
   getUploadUrl: ReturnType<typeof useDrinkLogs>['getUploadUrl']
   uploadToS3: ReturnType<typeof useDrinkLogs>['uploadToS3']
@@ -106,6 +110,13 @@ export const setPlaceOnPendingItems = (items: DrinkLogBatchItem[], placeId: stri
   })
 }
 
+/** True for the one create failure a retry with the same payload can never clear. */
+const isDatetimeRejection = (cause: unknown) => {
+  if (!(cause instanceof ApiError) || cause.status !== 400) return false
+  const fields = (cause.details as { fields?: unknown } | undefined)?.fields
+  return Boolean(fields && typeof fields === 'object' && 'datetime' in fields)
+}
+
 const processingError = (cause: unknown) => {
   if (cause instanceof ImageTooLargeError) return '画像を3.5MB以下にできませんでした。別の画像を選択してください。'
   return normalizeDrinkLogError(cause, '画像の準備または解析に失敗しました。')
@@ -114,6 +125,7 @@ const processingError = (cause: unknown) => {
 const newItem = (file: File, id: string): DrinkLogBatchItem => ({
   id,
   file,
+  capturedAt: null,
   phase: 'queued',
   uploadProgress: 0,
   previewUrl: '',
@@ -135,6 +147,7 @@ const newItem = (file: File, id: string): DrinkLogBatchItem => ({
 export const useDrinkLogBatch = (provided?: DrinkLogBatchDependencies) => {
   const drinkLogs = provided ? null : useDrinkLogs()
   const dependencies: DrinkLogBatchDependencies = provided || {
+    readExifCapturedAt,
     resizeImage,
     getUploadUrl: drinkLogs!.getUploadUrl,
     uploadToS3: drinkLogs!.uploadToS3,
@@ -171,6 +184,7 @@ export const useDrinkLogBatch = (provided?: DrinkLogBatchDependencies) => {
   const processItem = async (item: DrinkLogBatchItem) => {
     revokePreview(item)
     item.phase = 'resizing'
+    item.capturedAt = null
     item.uploadProgress = 0
     item.analysisId = ''
     item.candidates = []
@@ -183,6 +197,7 @@ export const useDrinkLogBatch = (provided?: DrinkLogBatchDependencies) => {
     item.createdLog = null
 
     try {
+      item.capturedAt = await dependencies.readExifCapturedAt(item.file)
       const resized = await dependencies.resizeImage(item.file)
       item.previewUrl = URL.createObjectURL(resized.blob)
       item.phase = 'uploading'
@@ -234,17 +249,29 @@ export const useDrinkLogBatch = (provided?: DrinkLogBatchDependencies) => {
 
     item.saveStatus = 'saving'
     item.saveError = ''
+    const payloadFor = (capturedAt: string | null) => buildDrinkLogPayload({
+      analysisId: item.analysisId,
+      capturedAt,
+      candidateIndex: item.selectedCandidateIndex,
+      brandText: item.brandText,
+      servingStyle: item.servingStyle,
+      storeName: item.storeName,
+      placeId: item.placeId,
+      notes: item.notes,
+      rating: item.rating,
+    })
     try {
-      const created = await dependencies.createLog(buildDrinkLogPayload({
-        analysisId: item.analysisId,
-        candidateIndex: item.selectedCandidateIndex,
-        brandText: item.brandText,
-        servingStyle: item.servingStyle,
-        storeName: item.storeName,
-        placeId: item.placeId,
-        notes: item.notes,
-        rating: item.rating,
-      }))
+      let created: DrinkLog
+      try {
+        created = await dependencies.createLog(payloadFor(item.capturedAt))
+      } catch (cause) {
+        // The server bounds the capture time against its own clock, so a device
+        // running fast enough gets a 400 the user could never resolve. Drop the
+        // EXIF time once and let the server stamp the record instead.
+        if (!isDatetimeRejection(cause)) throw cause
+        item.capturedAt = null
+        created = await dependencies.createLog(payloadFor(null))
+      }
       item.createdLog = created
       item.saveStatus = 'saved'
       return created

--- a/frontend/composables/useDrinkLogs.ts
+++ b/frontend/composables/useDrinkLogs.ts
@@ -45,6 +45,7 @@ export interface DrinkLog {
 
 export interface CreateDrinkLogPayload {
   analysis_id: string
+  datetime?: string
   candidate_index?: number
   brand_text?: string
   serving_style?: string
@@ -55,6 +56,7 @@ export interface CreateDrinkLogPayload {
 
 export interface DrinkLogFormValues {
   analysisId: string
+  capturedAt?: string | null
   candidateIndex: number | null
   brandText: string
   servingStyle?: string
@@ -130,6 +132,7 @@ export const normalizeDrinkLogError = (cause: unknown, fallback: string) => {
 
 export const buildDrinkLogPayload = (form: DrinkLogFormValues): CreateDrinkLogPayload => ({
   analysis_id: form.analysisId,
+  ...(form.capturedAt ? { datetime: form.capturedAt } : {}),
   ...(form.candidateIndex === null
     ? { brand_text: form.brandText.trim() }
     : { candidate_index: form.candidateIndex }),

--- a/frontend/pages/logs/[id].vue
+++ b/frontend/pages/logs/[id].vue
@@ -203,27 +203,12 @@ onMounted(async () => {
               <dt class="text-xs uppercase tracking-wide text-stone-400">飲み方</dt>
               <dd class="mt-1 text-amber-100">{{ servingStyleLabel(log.serving_style) }}</dd>
             </div>
-            <div>
-              <dt class="text-xs uppercase tracking-wide text-stone-400">状態</dt>
-              <dd class="mt-1 text-amber-100">{{ log.status }}</dd>
-            </div>
           </dl>
 
           <section class="mt-7">
             <h2 class="text-sm font-medium text-amber-200">ノート</h2>
             <p class="mt-2 whitespace-pre-wrap text-stone-200">{{ log.notes || 'ノートはありません。' }}</p>
           </section>
-
-          <details class="mt-7 rounded-md bg-stone-900/60 p-4 text-xs text-stone-400">
-            <summary class="cursor-pointer text-stone-300">記録情報</summary>
-            <dl class="mt-3 space-y-2 break-all">
-              <div><dt class="inline text-stone-500">記録ID: </dt><dd class="inline">{{ log.id }}</dd></div>
-              <div><dt class="inline text-stone-500">ユーザーID: </dt><dd class="inline">{{ log.user_id }}</dd></div>
-              <div><dt class="inline text-stone-500">作成日時: </dt><dd class="inline">{{ log.created_at || '不明' }}</dd></div>
-              <div><dt class="inline text-stone-500">更新日時: </dt><dd class="inline">{{ log.updated_at || '不明' }}</dd></div>
-              <div v-if="log.ai"><dt class="text-stone-500">AI解析:</dt><dd class="mt-1 whitespace-pre-wrap">{{ JSON.stringify(log.ai, null, 2) }}</dd></div>
-            </dl>
-          </details>
 
           <p v-if="actionError" role="alert" class="mt-6 rounded-md border border-red-800 bg-red-900/50 p-3 text-sm text-red-200">{{ actionError }}</p>
           <div v-if="isOwner" class="mt-7 flex justify-end gap-3">

--- a/frontend/pages/logs/new.vue
+++ b/frontend/pages/logs/new.vue
@@ -12,6 +12,7 @@ import {
 import { candidateIndexAfterBrandEdit, useDrinkLogs, type PlaceCandidate } from '~/composables/useDrinkLogs'
 import { useGeolocation } from '~/composables/useGeolocation'
 import { SERVING_STYLES, type ServingStyle } from '~/types/whiskey'
+import { formatLocalLogDate, formatLocalLogTime } from '~/utils/drinkLogs'
 import { readExifGps, type Coordinates } from '~/utils/exifLocation'
 
 const { searchPlaces, upsertLogs } = useDrinkLogs()
@@ -279,7 +280,7 @@ const openLightbox = (src: string, alt: string) => {
                 </span>
                 <span class="mt-1 block pl-6 text-xs text-stone-300">{{ place.formatted_address }}</span>
               </button>
-              <GoogleAttributions :attributions="place.attributions" />
+              <GoogleAttributions :attributions="place.attributions" :query="place.display_name" />
             </div>
           </div>
           <p class="text-xs text-stone-400">店を選ぶと未保存の写真すべてに適用されます。記録に残す店名は各カードで入力してください。</p>
@@ -302,7 +303,10 @@ const openLightbox = (src: string, alt: string) => {
           </button>
           <div>
             <h2 class="text-lg font-medium text-amber-200">{{ items.indexOf(item) + 1 }}杯目の確認</h2>
-            <p class="mt-1 text-xs text-stone-400">記録日時: 今（保存時刻）</p>
+            <p v-if="item.capturedAt" class="mt-1 text-xs text-stone-400">
+              撮影日時: {{ formatLocalLogDate(item.capturedAt) }} {{ formatLocalLogTime(item.capturedAt) }}
+            </p>
+            <p v-else class="mt-1 text-xs text-stone-400">記録日時: 保存時刻</p>
             <p v-if="item.saveStatus === 'saving'" class="mt-2 text-sm text-amber-300">保存中…</p>
             <p v-else-if="item.saveStatus === 'saved'" class="mt-2 text-sm text-emerald-300">保存完了</p>
             <p v-else-if="item.saveStatus === 'failed'" class="mt-2 text-sm text-red-200">保存失敗</p>
@@ -371,7 +375,11 @@ const openLightbox = (src: string, alt: string) => {
             <option value="">店を選ばない</option>
             <option v-for="place in places" :key="place.place_id" :value="place.place_id" class="bg-stone-700 text-amber-100">{{ place.display_name }}</option>
           </select>
-          <GoogleAttributions v-if="selectedPlaceFor(item)" :attributions="selectedPlaceAttributions(item)" />
+          <GoogleAttributions
+            v-if="selectedPlaceFor(item)"
+            :attributions="selectedPlaceAttributions(item)"
+            :query="selectedPlaceFor(item)?.display_name"
+          />
 
           <label :for="`store-name-${item.id}`" class="mt-4 block text-sm font-medium text-amber-200">記録に残す店名（任意）</label>
           <input :id="`store-name-${item.id}`" v-model="item.storeName" :disabled="item.saveStatus === 'saved'" type="text" maxlength="200" placeholder="例: いつものバー" class="mt-2 block w-full rounded-md border-amber-700 bg-stone-700 text-amber-100 placeholder:text-stone-400 disabled:opacity-50" />

--- a/frontend/tests/components/googleAttributions.test.ts
+++ b/frontend/tests/components/googleAttributions.test.ts
@@ -1,0 +1,29 @@
+import { mount } from '@vue/test-utils'
+import { describe, expect, it } from 'vitest'
+import GoogleAttributions from '~/components/GoogleAttributions.vue'
+
+describe('GoogleAttributions', () => {
+  it('links Google Maps to a URL-encoded place-name search', () => {
+    const wrapper = mount(GoogleAttributions, {
+      props: { attributions: [], query: 'Bar 621 東京' },
+    })
+    const link = wrapper.get('a')
+
+    expect(link.text()).toBe('Google Maps')
+    expect(link.attributes()).toMatchObject({
+      href: 'https://www.google.com/maps/search/?api=1&query=Bar%20621%20%E6%9D%B1%E4%BA%AC',
+      target: '_blank',
+      rel: 'noopener noreferrer',
+      translate: 'no',
+    })
+  })
+
+  it.each([undefined, ''])('keeps Google Maps as plain text without a query (%s)', query => {
+    const wrapper = mount(GoogleAttributions, {
+      props: { attributions: [], query },
+    })
+
+    expect(wrapper.text()).toContain('Google Maps')
+    expect(wrapper.find('a').exists()).toBe(false)
+  })
+})

--- a/frontend/tests/composables/useDrinkLogBatch.test.ts
+++ b/frontend/tests/composables/useDrinkLogBatch.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, expectTypeOf, it, vi } from 'vitest'
+import { ApiError } from '~/composables/useApi'
 import {
   clearPendingItemPlaceIds,
   copyStoreToPendingItems,
@@ -24,6 +25,7 @@ const makeDependencies = () => {
   let uploadSequence = 0
   let createSequence = 0
   return {
+    readExifCapturedAt: vi.fn(async (_file: File): Promise<string | null> => null),
     resizeImage: vi.fn(async () => ({ blob: new Blob(['jpeg'], { type: 'image/jpeg' }), contentType: 'image/jpeg' })),
     getUploadUrl: vi.fn(async (_contentType: string) => ({ upload_url: 'https://upload.test', fields: {}, s3_key: `photo-${++uploadSequence}` })),
     uploadToS3: vi.fn(async (_url, _fields, _blob, onProgress) => onProgress?.(100)),
@@ -99,6 +101,57 @@ describe('useDrinkLogBatch', () => {
     await batch.savePending()
 
     expect(dependencies.createLog.mock.calls[0]?.[0]).not.toHaveProperty('store')
+  })
+
+  it('reads capture time from the original file and includes it when saving', async () => {
+    const dependencies = makeDependencies()
+    dependencies.readExifCapturedAt.mockResolvedValue('2026-08-01T21:30:00+09:00')
+    const batch = useDrinkLogBatch(dependencies)
+    const original = new File(['original-with-exif'], 'captured.jpg', { type: 'image/jpeg' })
+
+    await batch.processFiles([original])
+    await batch.savePending()
+
+    expect(dependencies.readExifCapturedAt).toHaveBeenCalledWith(original)
+    expect(dependencies.createLog).toHaveBeenCalledWith(expect.objectContaining({
+      datetime: '2026-08-01T21:30:00+09:00',
+    }))
+  })
+
+  it('retries once without the capture time when the server rejects it', async () => {
+    const dependencies = makeDependencies()
+    dependencies.readExifCapturedAt.mockResolvedValue('2126-08-01T21:30:00+09:00')
+    // A device clock running ahead of the server produces a 400 that resending
+    // the same payload could never clear.
+    dependencies.createLog.mockRejectedValueOnce(
+      new ApiError('Validation failed', 400, { error: 'Validation failed', fields: { datetime: 'Must be RFC3339' } }),
+    )
+    const batch = useDrinkLogBatch(dependencies)
+
+    await batch.processFiles([new File(['photo'], 'skewed.jpg', { type: 'image/jpeg' })])
+    await batch.savePending()
+
+    expect(dependencies.createLog).toHaveBeenCalledTimes(2)
+    expect(dependencies.createLog.mock.calls[0]?.[0]).toHaveProperty('datetime')
+    expect(dependencies.createLog.mock.calls[1]?.[0]).not.toHaveProperty('datetime')
+    expect(batch.items.value[0]?.saveStatus).toBe('saved')
+    expect(batch.items.value[0]?.capturedAt).toBeNull()
+  })
+
+  it('does not retry a save failure unrelated to the capture time', async () => {
+    const dependencies = makeDependencies()
+    dependencies.readExifCapturedAt.mockResolvedValue('2026-08-01T21:30:00+09:00')
+    dependencies.createLog.mockRejectedValueOnce(
+      new ApiError('Validation failed', 400, { error: 'Validation failed', fields: { brand_text: 'Field is required' } }),
+    )
+    const batch = useDrinkLogBatch(dependencies)
+
+    await batch.processFiles([new File(['photo'], 'invalid.jpg', { type: 'image/jpeg' })])
+    await batch.savePending()
+
+    expect(dependencies.createLog).toHaveBeenCalledTimes(1)
+    expect(batch.items.value[0]?.saveStatus).toBe('failed')
+    expect(batch.items.value[0]?.capturedAt).toBe('2026-08-01T21:30:00+09:00')
   })
 
   it('saves degraded analysis with a manually entered brand', async () => {

--- a/frontend/tests/composables/useDrinkLogs.test.ts
+++ b/frontend/tests/composables/useDrinkLogs.test.ts
@@ -7,7 +7,7 @@ vi.mock('~/composables/useApi', async importOriginal => {
   return { ...actual, useApi: () => ({ request }) }
 })
 
-import { useDrinkLogs } from '~/composables/useDrinkLogs'
+import { buildDrinkLogPayload, useDrinkLogs } from '~/composables/useDrinkLogs'
 
 const record = (id: string, datetime: string, brandText = id) => ({
   id,
@@ -52,6 +52,28 @@ describe('useDrinkLogs API contract', () => {
     expect(request).toHaveBeenNthCalledWith(3, '/api/drink-logs', {
       method: 'POST', auth: 'required', body: { analysis_id: 'a1', candidate_index: 0 },
     })
+  })
+
+  it('maps capturedAt to datetime and omits the key when no capture time exists', () => {
+    expect(buildDrinkLogPayload({
+      analysisId: 'a1',
+      capturedAt: '2026-08-01T21:30:00+09:00',
+      candidateIndex: 0,
+      brandText: 'AI銘柄',
+    })).toEqual({
+      analysis_id: 'a1',
+      datetime: '2026-08-01T21:30:00+09:00',
+      candidate_index: 0,
+    })
+
+    for (const capturedAt of [null, undefined]) {
+      expect(buildDrinkLogPayload({
+        analysisId: 'a1',
+        capturedAt,
+        candidateIndex: 0,
+        brandText: 'AI銘柄',
+      })).not.toHaveProperty('datetime')
+    }
   })
 
   it('uses every list, detail, update, delete and Places endpoint with required auth', async () => {

--- a/frontend/tests/mocks/exifr.ts
+++ b/frontend/tests/mocks/exifr.ts
@@ -2,6 +2,7 @@ import { vi } from 'vitest'
 
 const exifr = {
   gps: vi.fn(),
+  parse: vi.fn(),
 }
 
 export default exifr

--- a/frontend/tests/pages/logsDetail.test.ts
+++ b/frontend/tests/pages/logsDetail.test.ts
@@ -46,4 +46,12 @@ describe('log detail editing and deletion', () => {
     expect(source).toContain('lightbox.src = log.value.image_url')
     expect(source).toContain('<ImageLightbox v-model:open="lightbox.open"')
   })
+
+  it('omits the record-information toggle and status field', () => {
+    expect(source).not.toContain('<summary class="cursor-pointer text-stone-300">記録情報</summary>')
+    expect(source).not.toContain('<dt class="text-xs uppercase tracking-wide text-stone-400">状態</dt>')
+    expect(source).not.toContain('log.created_at')
+    expect(source).not.toContain('log.updated_at')
+    expect(source).not.toContain('JSON.stringify(log.ai')
+  })
 })

--- a/frontend/tests/pages/logsNew.test.ts
+++ b/frontend/tests/pages/logsNew.test.ts
@@ -14,6 +14,7 @@ import {
 import { buildDrinkLogPayload, candidateIndexAfterBrandEdit, type DrinkLogCandidate, type PlaceCandidate } from '~/composables/useDrinkLogs'
 import LogsNewPage from '~/pages/logs/new.vue'
 import { SERVING_STYLES } from '~/types/whiskey'
+import { formatLocalLogDate, formatLocalLogTime } from '~/utils/drinkLogs'
 
 const pageMocks = vi.hoisted(() => ({
   processFiles: vi.fn(),
@@ -95,6 +96,7 @@ if (!template) throw new Error('logs/new.vue template not found')
 const batchItem = (candidates: DrinkLogCandidate[] = [], index = 0): DrinkLogBatchItem => ({
   id: `photo-${index + 1}`,
   file: new File(['photo'], 'photo.jpg', { type: 'image/jpeg' }),
+  capturedAt: null,
   phase: 'ready',
   uploadProgress: 100,
   previewUrl: 'blob:preview',
@@ -119,6 +121,7 @@ const renderLogPage = (options: {
   candidates?: DrinkLogCandidate[]
   places?: PlaceCandidate[]
   itemCount?: number
+  capturedAt?: string | null
 } = {}) => mount(defineComponent({
   setup: () => {
     const lightbox = reactive({ open: false, src: '', alt: '' })
@@ -126,6 +129,9 @@ const renderLogPage = (options: {
       { length: options.itemCount || 1 },
       (_, index) => batchItem(options.candidates || [], index),
     ))
+    items.value.forEach(item => {
+      item.capturedAt = options.capturedAt || null
+    })
     const places = ref(options.places || [])
     const readyItems = computed(() => items.value.filter(item => item.phase === 'ready'))
     const selectCandidate = (item: ReturnType<typeof batchItem>, index: number) => {
@@ -173,6 +179,8 @@ const renderLogPage = (options: {
       SERVING_STYLES,
       styleLabels: { NEAT: 'ストレート', ROCKS: 'ロック', WATER: '水割り', SODA: 'ハイボール', COCKTAIL: 'カクテル' },
       processingLabels: { queued: '処理中', resizing: '処理中', uploading: '処理中', analyzing: '処理中', ready: '解析完了', failed: '失敗' },
+      formatLocalLogDate,
+      formatLocalLogTime,
       handleFileSelection: vi.fn(),
       handleSubmit: vi.fn(),
       selectCandidate,
@@ -228,6 +236,11 @@ describe('logs/new form behavior', () => {
       analysis_id: 'a1',
       candidate_index: 0,
     })
+  })
+
+  it('shows a captured timestamp when EXIF exists and a save-time fallback otherwise', () => {
+    expect(renderLogPage({ capturedAt: '2026-07-01T21:30:00+09:00' }).text()).toContain('撮影日時:')
+    expect(renderLogPage().text()).toContain('記録日時: 保存時刻')
   })
 
   it('sends brand_text without candidate_index for manual input', () => {

--- a/frontend/tests/pages/placeResolution.test.ts
+++ b/frontend/tests/pages/placeResolution.test.ts
@@ -85,11 +85,56 @@ describe('visible Places resolution and attribution', () => {
     expect(wrapper.text()).toContain('Google Bar')
     expect(wrapper.text()).toContain('Google Maps')
     expect(wrapper.text()).toContain('Provider')
+    expect(wrapper.get('a').attributes('href')).toBe(
+      'https://www.google.com/maps/search/?api=1&query=Google%20Bar',
+    )
 
     for (const page of ['pages/logs/index.vue', 'pages/logs/[id].vue']) {
       const pageSource = readFileSync(resolve(process.cwd(), page), 'utf8')
       expect(pageSource).toContain('<DrinkLogStoreDisplay')
       expect(pageSource).toContain(':resolved-place=')
     }
+  })
+
+  it.each([
+    [{ name: '', place_id: 'place-1' }, '場所登録済み'],
+    [{ name: '' }, '場所未登録'],
+  ])('does not search for the %s placeholder', (store, placeholder) => {
+    const wrapper = mount(DrinkLogStoreDisplay, {
+      props: {
+        log: { ...record(1), store },
+        resolvedPlace: {
+          log_id: 'log-1',
+          display_name: '',
+          name_source: 'google',
+          attributions: [],
+        },
+      },
+      global: { components: { GoogleAttributions } },
+    })
+
+    expect(wrapper.text()).toContain(placeholder)
+    expect(wrapper.find('a').exists()).toBe(false)
+  })
+
+  it('does not search for the Places resolution failure placeholder', () => {
+    // PLACEHOLDER_NAME in lambda/drink-log-analyze/places.py: returned with
+    // name_source "google" when the lookup fails, so it reaches the display
+    // through the same path as a real resolved name.
+    const wrapper = mount(DrinkLogStoreDisplay, {
+      props: {
+        log: { ...record(1), store: { name: '', place_id: 'place-1' } },
+        resolvedPlace: {
+          log_id: 'log-1',
+          display_name: '店舗情報を取得できません',
+          name_source: 'google',
+          attributions: [],
+        },
+      },
+      global: { components: { GoogleAttributions } },
+    })
+
+    expect(wrapper.text()).toContain('店舗情報を取得できません')
+    expect(wrapper.find('a').exists()).toBe(false)
   })
 })

--- a/frontend/tests/utils/exifCapturedAt.test.ts
+++ b/frontend/tests/utils/exifCapturedAt.test.ts
@@ -1,0 +1,81 @@
+import exifr from 'exifr'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { readExifCapturedAt } from '~/utils/exifCapturedAt'
+
+const parseMock = vi.mocked(exifr.parse)
+const file = new File(['image'], 'photo.jpg', { type: 'image/jpeg' })
+
+describe('readExifCapturedAt', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-01T12:30:00Z'))
+    parseMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('returns offset-aware RFC3339 from DateTimeOriginal', async () => {
+    parseMock.mockResolvedValue({
+      DateTimeOriginal: '2026:08:01 21:30:00',
+      OffsetTimeOriginal: '+09:00',
+    })
+
+    await expect(readExifCapturedAt(file)).resolves.toBe('2026-08-01T21:30:00+09:00')
+    expect(parseMock).toHaveBeenCalledWith(file, expect.objectContaining({
+      pick: ['DateTimeOriginal', 'OffsetTimeOriginal', 'CreateDate'],
+      reviveValues: false,
+    }))
+  })
+
+  it('interprets an offset-less timestamp in the browser local timezone', async () => {
+    parseMock.mockResolvedValue({ DateTimeOriginal: '2026:07:01 21:30:00' })
+    const expectedInstant = new Date(2026, 6, 1, 21, 30, 0).getTime()
+
+    const result = await readExifCapturedAt(file)
+
+    expect(result).toMatch(/^2026-07-01T21:30:00[+-]\d{2}:\d{2}$/)
+    expect(Date.parse(result!)).toBe(expectedInstant)
+  })
+
+  it('falls back to CreateDate when DateTimeOriginal is absent', async () => {
+    parseMock.mockResolvedValue({
+      CreateDate: '2026:07:01 10:00:00',
+      OffsetTimeOriginal: 'Z',
+    })
+
+    await expect(readExifCapturedAt(file)).resolves.toBe('2026-07-01T10:00:00Z')
+  })
+
+  it('returns null when capture metadata is absent', async () => {
+    parseMock.mockResolvedValue({})
+
+    await expect(readExifCapturedAt(file)).resolves.toBeNull()
+  })
+
+  it.each([
+    { DateTimeOriginal: 'not-a-date' },
+    { DateTimeOriginal: '2026:02:30 10:00:00' },
+    { DateTimeOriginal: '2026:07:01 10:00:00', OffsetTimeOriginal: 'UTC+9' },
+  ])('returns null for broken EXIF values: %o', async metadata => {
+    parseMock.mockResolvedValue(metadata)
+
+    await expect(readExifCapturedAt(file)).resolves.toBeNull()
+  })
+
+  it.each([
+    { DateTimeOriginal: '1999:12:31 23:59:59', OffsetTimeOriginal: 'Z' },
+    { DateTimeOriginal: '2026:08:01 12:36:00', OffsetTimeOriginal: 'Z' },
+  ])('returns null for out-of-range capture times: %o', async metadata => {
+    parseMock.mockResolvedValue(metadata)
+
+    await expect(readExifCapturedAt(file)).resolves.toBeNull()
+  })
+
+  it('returns null instead of throwing when EXIF parsing fails', async () => {
+    parseMock.mockRejectedValue(new Error('unsupported image'))
+
+    await expect(readExifCapturedAt(file)).resolves.toBeNull()
+  })
+})

--- a/frontend/utils/drinkLogs.ts
+++ b/frontend/utils/drinkLogs.ts
@@ -50,3 +50,11 @@ export const servingStyleLabel = (style?: string) => ({
   SODA: 'ハイボール',
   COCKTAIL: 'カクテル',
 }[style || ''] || style || '指定なし')
+
+/**
+ * Stand-in names shown when there is no real store name to display: no place at
+ * all, a place_id we deliberately never resolved, or a Places lookup that failed
+ * (`PLACEHOLDER_NAME` in lambda/drink-log-analyze/places.py). None of them are
+ * meaningful as a Google Maps search query.
+ */
+export const STORE_NAME_PLACEHOLDERS = ['場所登録済み', '場所未登録', '店舗情報を取得できません']

--- a/frontend/utils/exifCapturedAt.ts
+++ b/frontend/utils/exifCapturedAt.ts
@@ -1,0 +1,146 @@
+interface ExifDateParts {
+  year: number
+  month: number
+  day: number
+  hour: number
+  minute: number
+  second: number
+  millisecond: number
+}
+
+const EARLIEST_CAPTURED_AT = Date.UTC(2000, 0, 1)
+const MAX_FUTURE_MILLISECONDS = 5 * 60 * 1000
+
+const pad = (value: number) => String(value).padStart(2, '0')
+
+const validParts = (parts: ExifDateParts) => {
+  const daysInMonth = new Date(Date.UTC(parts.year, parts.month, 0)).getUTCDate()
+  return parts.year >= 1
+    && parts.month >= 1
+    && parts.month <= 12
+    && parts.day >= 1
+    && parts.day <= daysInMonth
+    && parts.hour >= 0
+    && parts.hour <= 23
+    && parts.minute >= 0
+    && parts.minute <= 59
+    && parts.second >= 0
+    && parts.second <= 59
+}
+
+const dateParts = (value: unknown): ExifDateParts | null => {
+  if (value instanceof Date) {
+    if (Number.isNaN(value.getTime())) return null
+    return {
+      year: value.getFullYear(),
+      month: value.getMonth() + 1,
+      day: value.getDate(),
+      hour: value.getHours(),
+      minute: value.getMinutes(),
+      second: value.getSeconds(),
+      millisecond: value.getMilliseconds(),
+    }
+  }
+  if (typeof value !== 'string') return null
+  const match = /^(\d{4})[:-](\d{2})[:-](\d{2})[ T](\d{2}):(\d{2}):(\d{2})(?:\.(\d+))?$/.exec(value.trim())
+  if (!match) return null
+  const parts = {
+    year: Number(match[1]),
+    month: Number(match[2]),
+    day: Number(match[3]),
+    hour: Number(match[4]),
+    minute: Number(match[5]),
+    second: Number(match[6]),
+    millisecond: Number((match[7] || '').slice(0, 3).padEnd(3, '0')),
+  }
+  return validParts(parts) ? parts : null
+}
+
+const exifOffset = (value: unknown) => {
+  if (value === 'Z') return { text: 'Z', minutes: 0 }
+  if (typeof value !== 'string') return null
+  const match = /^([+-])(\d{2}):?(\d{2})$/.exec(value.trim())
+  if (!match) return null
+  const hours = Number(match[2])
+  const minutes = Number(match[3])
+  if (hours > 23 || minutes > 59) return null
+  const direction = match[1] === '+' ? 1 : -1
+  return {
+    text: `${match[1]}${pad(hours)}:${pad(minutes)}`,
+    minutes: direction * (hours * 60 + minutes),
+  }
+}
+
+const wallClock = (parts: ExifDateParts) => (
+  `${String(parts.year).padStart(4, '0')}-${pad(parts.month)}-${pad(parts.day)}`
+  + `T${pad(parts.hour)}:${pad(parts.minute)}:${pad(parts.second)}`
+)
+
+const capturedAt = (value: unknown, rawOffset: unknown): string | null => {
+  const parts = dateParts(value)
+  if (!parts) return null
+  const offset = exifOffset(rawOffset)
+  let instant: number
+  let offsetText: string
+
+  if (rawOffset !== undefined && rawOffset !== null && !offset) return null
+  if (offset) {
+    instant = Date.UTC(
+      parts.year,
+      parts.month - 1,
+      parts.day,
+      parts.hour,
+      parts.minute,
+      parts.second,
+      parts.millisecond,
+    ) - offset.minutes * 60 * 1000
+    offsetText = offset.text
+  } else {
+    const local = new Date(
+      parts.year,
+      parts.month - 1,
+      parts.day,
+      parts.hour,
+      parts.minute,
+      parts.second,
+      parts.millisecond,
+    )
+    if (
+      local.getFullYear() !== parts.year
+      || local.getMonth() !== parts.month - 1
+      || local.getDate() !== parts.day
+      || local.getHours() !== parts.hour
+      || local.getMinutes() !== parts.minute
+      || local.getSeconds() !== parts.second
+    ) return null
+    instant = local.getTime()
+    const localOffsetMinutes = -local.getTimezoneOffset()
+    const sign = localOffsetMinutes >= 0 ? '+' : '-'
+    const absoluteOffset = Math.abs(localOffsetMinutes)
+    offsetText = `${sign}${pad(Math.floor(absoluteOffset / 60))}:${pad(absoluteOffset % 60)}`
+  }
+
+  if (
+    !Number.isFinite(instant)
+    || instant < EARLIEST_CAPTURED_AT
+    || instant > Date.now() + MAX_FUTURE_MILLISECONDS
+  ) return null
+  return `${wallClock(parts)}${offsetText}`
+}
+
+/** 元ファイルの EXIF から撮影日時を読む。無い/不正なら null。 */
+export const readExifCapturedAt = async (file: File): Promise<string | null> => {
+  try {
+    const exifr = (await import('exifr')).default
+    const metadata = await exifr.parse(file, {
+      exif: true,
+      gps: false,
+      pick: ['DateTimeOriginal', 'OffsetTimeOriginal', 'CreateDate'],
+      reviveValues: false,
+    }) as Record<string, unknown> | undefined
+    if (!metadata) return null
+    return capturedAt(metadata.DateTimeOriginal ?? metadata.CreateDate, metadata.OffsetTimeOriginal)
+  } catch {
+    return null
+  }
+}

--- a/lambda/drink-logs/index.py
+++ b/lambda/drink-logs/index.py
@@ -51,7 +51,7 @@ CONTENT_TYPES = {
     "image/webp": ("webp", "webp"),
 }
 UPDATE_FIELDS = {"brand_text", "store", "notes", "rating", "serving_style"}
-CREATE_FIELDS = {"analysis_id", "candidate_index"} | UPDATE_FIELDS
+CREATE_FIELDS = {"analysis_id", "candidate_index", "datetime"} | UPDATE_FIELDS
 # Strip internal bookkeeping and raw bucket-key structure from API responses.
 # Clients receive a presigned `image_url` instead of the raw S3 keys; the quota
 # and delete-lifecycle fields are server-side reconciliation state only.
@@ -72,6 +72,9 @@ PRESIGNED_GET_SECONDS = 900
 NAMESPACE_DRINKLOG = uuid.UUID("7df1920f-5929-51ee-9860-164c1d4bc388")
 UUID_TEXT = r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}"
 ANALYSIS_ID_RE = re.compile(rf"^(?:ai-result:([^:]+):)?({UUID_TEXT})$")
+RFC3339_WITH_OFFSET_RE = re.compile(
+    r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$"
+)
 
 
 class ValidationError(ValueError):
@@ -112,7 +115,28 @@ def _utc_now() -> datetime:
 
 
 def _rfc3339(value: datetime) -> str:
-    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+    return (
+        value.astimezone(timezone.utc)
+        .isoformat(timespec="milliseconds")
+        .replace("+00:00", "Z")
+    )
+
+
+def _validate_create_datetime(value: Any) -> str | None:
+    if not isinstance(value, str) or not RFC3339_WITH_OFFSET_RE.fullmatch(value):
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.utcoffset() is None:
+        return None
+    normalized = parsed.astimezone(timezone.utc)
+    if normalized < datetime(2000, 1, 1, tzinfo=timezone.utc):
+        return None
+    if normalized > _utc_now() + timedelta(minutes=5):
+        return None
+    return _rfc3339(normalized)
 
 
 def _request_id(event: Mapping[str, Any], context: Any) -> str:
@@ -181,6 +205,14 @@ def validate_create_input(data: Mapping[str, Any]) -> dict[str, Any]:
     ):
         errors["candidate_index"] = "Must be a non-negative integer"
 
+    validated_datetime = None
+    if "datetime" in data:
+        validated_datetime = _validate_create_datetime(data["datetime"])
+        if validated_datetime is None:
+            errors["datetime"] = (
+                "Must be RFC3339 with an offset or Z and between 2000-01-01 and 5 minutes from now"
+            )
+
     mutable_input = {field: data[field] for field in UPDATE_FIELDS if field in data}
     validated_mutable: dict[str, Any] = {}
     if mutable_input:
@@ -193,6 +225,8 @@ def validate_create_input(data: Mapping[str, Any]) -> dict[str, Any]:
     validated = {"analysis_id": analysis_id, **validated_mutable}
     if "candidate_index" in data:
         validated["candidate_index"] = candidate_index
+    if validated_datetime is not None:
+        validated["datetime"] = validated_datetime
     return validated
 
 
@@ -582,7 +616,7 @@ def _prepare_initial_record(
         "id": derive_drink_log_id(user_id, upload_uuid),
         "user_id": user_id,
         "status": "pending",
-        "datetime": now,
+        "datetime": (overrides or {}).get("datetime", now),
         "tmp_s3_key": s3_key,
         "tmp_etag": etag,
         "content_type": content_type,

--- a/swagger.yml
+++ b/swagger.yml
@@ -75,6 +75,11 @@ paths:
     post:
       security: [{bearerAuth: []}]
       summary: Create a drink log
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: {$ref: '#/components/schemas/CreateDrinkLogRequest'}
       responses:
         '501': {$ref: '#/components/responses/NotImplemented'}
     get:
@@ -163,6 +168,25 @@ components:
     ServingStyle:
       type: string
       enum: [NEAT, ROCKS, WATER, SODA, COCKTAIL]
+    CreateDrinkLogRequest:
+      type: object
+      required: [analysis_id]
+      properties:
+        analysis_id: {type: string}
+        candidate_index: {type: integer, minimum: 0}
+        datetime:
+          type: string
+          format: date-time
+          description: Optional RFC3339 capture time with an explicit offset or Z; accepted from 2000-01-01T00:00:00Z through five minutes after the current server time. Defaults to server time and is normalized to UTC.
+        brand_text: {type: string, maxLength: 200}
+        serving_style: {$ref: '#/components/schemas/ServingStyle'}
+        store:
+          type: object
+          properties:
+            name: {type: string, maxLength: 200, description: User-entered name only}
+            place_id: {type: string}
+        notes: {type: string, maxLength: 2000}
+        rating: {$ref: '#/components/schemas/Rating'}
     DrinkLog:
       type: object
       description: GPS coordinates and Google-provided display names are never stored.

--- a/tests/lambda/test_drink_logs.py
+++ b/tests/lambda/test_drink_logs.py
@@ -399,7 +399,7 @@ def test_create_validation_accepts_optional_candidate_and_reuses_update_rules():
                 "notes": "x" * 2001,
                 "rating": 0,
                 "serving_style": "INVALID",
-                "datetime": "2020-01-01T00:00:00Z",
+                "datetime": "2020-01-01T00:00:00",
             }
         )
     assert set(exc.value.fields) == {
@@ -411,6 +411,116 @@ def test_create_validation_accepts_optional_candidate_and_reuses_update_rules():
         "serving_style",
         "store.name",
     }
+
+
+def test_create_datetime_is_normalized_without_replacing_audit_timestamps(monkeypatch):
+    fixed_now = datetime.now(timezone.utc).replace(microsecond=123456)
+    captured_utc = fixed_now.replace(microsecond=0) - timedelta(hours=1)
+    captured_with_offset = captured_utc.astimezone(
+        timezone(timedelta(hours=9))
+    ).isoformat()
+    monkeypatch.setattr(drink_logs, "_utc_now", lambda: fixed_now)
+
+    with mock_aws():
+        dynamodb, s3, drinklogs, _app_state, analysis, _upload_uuid = (
+            _moto_create_dependencies()
+        )
+        record, created = drink_logs.create_drink_log(
+            dynamodb,
+            s3,
+            "DrinkLogs-test",
+            "AppState-test",
+            "images-test",
+            "user-1",
+            drink_logs.validate_create_input(
+                {
+                    "analysis_id": analysis["pk"],
+                    "candidate_index": 0,
+                    "datetime": captured_with_offset,
+                }
+            ),
+        )
+
+        expected_now = drink_logs._rfc3339(fixed_now)
+        expected_captured = drink_logs._rfc3339(captured_utc)
+        stored = drinklogs.get_item(Key={"id": record["id"]})["Item"]
+        assert created is True
+        assert record["datetime"] == expected_captured
+        assert stored["datetime"] == expected_captured
+        assert record["created_at"] == expected_now
+        assert record["updated_at"] == expected_now
+
+
+def test_create_datetime_normalizes_to_the_literal_sort_key_format(monkeypatch):
+    """The GSI sort key is compared lexicographically, so the shape is the contract.
+
+    Asserting against _rfc3339 would move with the implementation and let a
+    format change through unnoticed.
+    """
+    monkeypatch.setattr(
+        drink_logs,
+        "_utc_now",
+        lambda: datetime(2026, 8, 1, 12, 30, tzinfo=timezone.utc),
+    )
+
+    validated = drink_logs.validate_create_input(
+        {
+            "analysis_id": "12345678-1234-4234-8234-123456789abc",
+            "datetime": "2026-08-01T12:00:00+09:00",
+        }
+    )
+
+    assert validated["datetime"] == "2026-08-01T03:00:00.000Z"
+
+
+def test_create_datetime_defaults_to_server_time(monkeypatch):
+    fixed_now = datetime.now(timezone.utc).replace(microsecond=654321)
+    monkeypatch.setattr(drink_logs, "_utc_now", lambda: fixed_now)
+
+    with mock_aws():
+        dynamodb, s3, _drinklogs, _app_state, analysis, _upload_uuid = (
+            _moto_create_dependencies()
+        )
+        record, _created = drink_logs.create_drink_log(
+            dynamodb,
+            s3,
+            "DrinkLogs-test",
+            "AppState-test",
+            "images-test",
+            "user-1",
+            drink_logs.validate_create_input(
+                {"analysis_id": analysis["pk"], "candidate_index": 0}
+            ),
+        )
+
+        assert record["datetime"] == drink_logs._rfc3339(fixed_now)
+
+
+@pytest.mark.parametrize(
+    "datetime_value",
+    [
+        "2026-08-01T21:30:00",
+        "1999-12-31T23:59:59Z",
+        "future",
+    ],
+)
+def test_create_datetime_rejects_naive_and_out_of_range_values(
+    monkeypatch, datetime_value
+):
+    fixed_now = datetime(2026, 8, 1, 12, 30, tzinfo=timezone.utc)
+    monkeypatch.setattr(drink_logs, "_utc_now", lambda: fixed_now)
+    if datetime_value == "future":
+        datetime_value = drink_logs._rfc3339(fixed_now + timedelta(hours=1))
+
+    with pytest.raises(drink_logs.ValidationError) as exc:
+        drink_logs.validate_create_input(
+            {
+                "analysis_id": "12345678-1234-4234-8234-123456789abc",
+                "datetime": datetime_value,
+            }
+        )
+
+    assert "datetime" in exc.value.fields
 
 
 def test_empty_candidates_can_create_complete_manual_brand():
@@ -1158,6 +1268,29 @@ def test_update_is_whitelisted_and_owner_status_are_atomic():
     assert calls[0]["ConditionExpression"] == "#owner = :caller AND #status = :complete"
     assert "#store.#name = :store_name" in calls[0]["UpdateExpression"]
     assert "#store.#place_id" not in calls[0]["UpdateExpression"]
+
+
+def test_put_rejects_datetime_as_an_immutable_field(monkeypatch):
+    event = _post_event(
+        "/api/drink-logs/log-1",
+        {"datetime": "2026-08-01T12:30:00Z"},
+    )
+    event.update(
+        httpMethod="PUT",
+        pathParameters={"id": "log-1"},
+    )
+    dynamodb = FakeDynamoDB({"DrinkLogs-test": StaticTable()})
+    monkeypatch.setattr(drink_logs, "get_dynamodb_resource", lambda: dynamodb)
+    monkeypatch.setattr(drink_logs, "get_s3_client", PresignS3)
+
+    response = drink_logs.lambda_handler(
+        event, SimpleNamespace(aws_request_id="aws-request-1")
+    )
+
+    assert response["statusCode"] == 400
+    assert json.loads(response["body"])["fields"] == {
+        "datetime": "Field is not accepted"
+    }
 
 
 def test_batch_get_retries_unprocessed_keys_and_fails_closed():


### PR DESCRIPTION
Closes #26

## 変更

| # | 内容 |
|---|---|
| 1 | 「記録情報」トグル（記録ID・ユーザーID・作成/更新日時・AI解析JSON）を削除 |
| 2 | 「状態」項目を削除。残る `<dl>` は 日時 / 場所 / 飲み方 |
| 3 | 「Google Maps」の文言を Google マップ検索リンクに。**緯度経度ではなく店名**をクエリに使う |
| 4 | 日時に保存時刻ではなく**撮影日時**を表示 |

## 4 がバックエンドに触れる理由

`datetime` はこれまでサーバーが常に保存時刻で埋めており（`CREATE_FIELDS` に `datetime` が無い）、クライアントから撮影日時を渡す経路が存在しなかった。

- 作成 API で任意の `datetime` を受理。**オフセット必須の RFC3339 のみ**（naive は 400）、2000年より前と未来（+5分超）も 400
- UTC の `YYYY-MM-DDTHH:MM:SS.sssZ` に正規化。**GSI `UserDatetimeIndex` のソートキー**であり、字句順と時系列順の一致が崩れると履歴の並びが壊れる
- `created_at` / `updated_at` は実際の処理時刻のまま。監査と収束処理の根拠を撮影日時で上書きしない
- **PUT では受け付けない**（`UPDATE_FIELDS` に入れない）。ソートキーを後から動かせるようにしない
- 再開経路（`_finish_pending_create`）は確定済みの `datetime` を保持する

フロントは**元ファイル**の EXIF `DateTimeOriginal` を読む（canvas 再エンコード後は EXIF が消えるため）。`OffsetTimeOriginal` があればそれを、無ければ端末のローカルタイムゾーンとして解釈する。EXIF が無ければフィールドごと省略し、従来どおりサーバー時刻になる。

## レビュー指摘の反映

`codex-reviewer` が重要2件を検出、いずれも修正済み:

1. **Places 解決失敗時のプレースホルダ `店舗情報を取得できません` が検索クエリに漏れる** — `name_source: "google"` で返るため実名と同じ経路を通っていた。プレースホルダ一覧を `STORE_NAME_PLACEHOLDERS` に集約して除外
2. **端末時計の進みで保存が永久に失敗する** — フロントは端末時計、サーバーは自身の時計で上限を見るため、5分以上進んだ端末は 400 になり、同じ内容を再送するリトライでは絶対に通らない。`datetime` の 400 に限り撮影日時を落として一度だけ再送する

## 検証

- `python -m pytest tests`: **260 passed**
- frontend: `npm run lint` / `npm run typecheck` / `npx vitest run`（21ファイル・**148テスト**）/ `npm run generate` 全通過
- infra: `npm run build` + `npx jest`（46テスト）通過。**`infra/` は無変更**
- プライバシー不変条件: `display_name` の永続化経路は増えていない（表示中の名前を検索クエリに使うだけ）。緯度経度の保存・送信・URL 化なし。Google 由来の名前が出る箇所には帰属表示が残る

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FURbntamSSzLGDvU4rUVYG