### PR TITLE
fix(logs): 詳細画面の店名解決をビューポート待ちにしない

### DIFF
--- a/frontend/pages/logs/[id].vue
+++ b/frontend/pages/logs/[id].vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, reactive, ref, type ComponentPublicInstance } from 'vue'
+import { computed, onMounted, reactive, ref } from 'vue'
 import { ApiError } from '~/composables/useApi'
 import {
   buildUpdateDrinkLogPayload,
@@ -8,7 +8,7 @@ import {
   type DrinkLogEditValues,
 } from '~/composables/useDrinkLogs'
 import { useAuth } from '~/composables/useAuth'
-import { useVisiblePlaceResolver } from '~/composables/useVisiblePlaceResolver'
+import { needsPlaceResolution, useVisiblePlaceResolver } from '~/composables/useVisiblePlaceResolver'
 import { SERVING_STYLES, type ServingStyle } from '~/types/whiskey'
 import { formatLocalLogDate, formatLocalLogTime, servingStyleLabel } from '~/utils/drinkLogs'
 
@@ -17,7 +17,7 @@ const router = useRouter()
 const logId = computed(() => String(route.params.id || ''))
 const { currentUserId, waitForAuthReady } = useAuth()
 const { getLog, updateLog, deleteLog, upsertLog, removeLog } = useDrinkLogs()
-const { resolvedPlaces, register: registerPlace } = useVisiblePlaceResolver()
+const { resolvedPlaces, enqueue: enqueuePlaces } = useVisiblePlaceResolver()
 
 const log = ref<DrinkLog | null>(null)
 const initialLoading = ref(true)
@@ -66,8 +66,14 @@ const copyLogToForm = (record: DrinkLog) => {
   form.notes = record.notes || ''
 }
 
-const registerStore = (target: Element | ComponentPublicInstance | null) => {
-  if (log.value) registerPlace(target, log.value)
+/**
+ * Resolve straight away rather than waiting to scroll the row into view. This
+ * page shows exactly one record, so deferring saves no Places call, and the
+ * viewport trigger never fires at all while the tab is hidden.
+ */
+const resolveStore = (record: DrinkLog) => {
+  if (!needsPlaceResolution(record)) return
+  enqueuePlaces([{ log_id: record.id, place_id: record.store.place_id as string }])
 }
 
 const handleRefreshedImage = (refreshed: DrinkLog) => {
@@ -139,6 +145,7 @@ onMounted(async () => {
     log.value = record
     upsertLog(record)
     copyLogToForm(record)
+    resolveStore(record)
   } catch (cause) {
     loadError.value = cause instanceof ApiError && cause.status === 404
       ? '記録が見つかりません。削除されたか、表示する権限がありません。'
@@ -191,11 +198,7 @@ onMounted(async () => {
               <dt class="text-xs uppercase tracking-wide text-stone-400">日時</dt>
               <dd class="mt-1 text-amber-100"><time :datetime="log.datetime">{{ formatLocalLogDate(log.datetime) }} {{ formatLocalLogTime(log.datetime) }}</time></dd>
             </div>
-            <div
-              :ref="registerStore"
-              :data-log-id="log.id"
-              :data-place-id="log.store.place_id || undefined"
-            >
+            <div :data-log-id="log.id" :data-place-id="log.store.place_id || undefined">
               <dt class="text-xs uppercase tracking-wide text-stone-400">場所</dt>
               <dd class="mt-1 text-amber-100"><DrinkLogStoreDisplay :log="log" :resolved-place="resolvedPlaces[log.id]" /></dd>
             </div>

--- a/frontend/tests/pages/logsDetailPlaceResolution.test.ts
+++ b/frontend/tests/pages/logsDetailPlaceResolution.test.ts
@@ -1,0 +1,116 @@
+import { mount } from '@vue/test-utils'
+import { nextTick } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { DrinkLog } from '~/composables/useDrinkLogs'
+
+const record = (store: DrinkLog['store']): DrinkLog => ({
+  id: 'log-1',
+  user_id: 'user-1',
+  status: 'complete',
+  datetime: '2026-07-25T11:58:37.000Z',
+  brand_text: '響',
+  brand_source: 'manual',
+  store,
+})
+
+const resolvePlaces = vi.fn()
+const getLog = vi.fn()
+
+vi.mock('~/composables/useDrinkLogs', async importOriginal => {
+  const actual = await importOriginal<typeof import('~/composables/useDrinkLogs')>()
+  return {
+    ...actual,
+    useDrinkLogs: () => ({
+      getLog,
+      updateLog: vi.fn(),
+      deleteLog: vi.fn(),
+      upsertLog: vi.fn(),
+      removeLog: vi.fn(),
+      resolvePlaces,
+    }),
+  }
+})
+
+vi.mock('~/composables/useAuth', () => ({
+  useAuth: () => ({
+    currentUserId: { value: 'user-1' },
+    waitForAuthReady: vi.fn(async () => {}),
+  }),
+}))
+
+/**
+ * Chrome delivers no IntersectionObserver entries while a tab is hidden, so a
+ * detail page that waits for one would show a placeholder forever. Never
+ * invoking the callback here reproduces that environment.
+ */
+class SilentIntersectionObserver {
+  observe = vi.fn()
+  unobserve = vi.fn()
+  disconnect = vi.fn()
+}
+
+vi.stubGlobal('IntersectionObserver', SilentIntersectionObserver)
+vi.stubGlobal('useRoute', () => ({ params: { id: 'log-1' } }))
+vi.stubGlobal('useRouter', () => ({ push: vi.fn() }))
+vi.stubGlobal('navigateTo', vi.fn())
+
+const { default: LogsDetailPage } = await import('~/pages/logs/[id].vue')
+const { default: DrinkLogStoreDisplay } = await import('~/components/DrinkLogStoreDisplay.vue')
+const { default: GoogleAttributions } = await import('~/components/GoogleAttributions.vue')
+
+const mountDetail = async () => {
+  const wrapper = mount(LogsDetailPage, {
+    global: {
+      components: { DrinkLogStoreDisplay, GoogleAttributions },
+      stubs: { NuxtLink: true, ImageLightbox: true, DrinkLogImage: true },
+    },
+  })
+  await new Promise(resolve => setTimeout(resolve, 0))
+  await nextTick()
+  await nextTick()
+  return wrapper
+}
+
+describe('detail page place resolution', () => {
+  beforeEach(() => {
+    resolvePlaces.mockReset()
+    resolvePlaces.mockImplementation(async (items: { log_id: string }[]) => items.map(item => ({
+      log_id: item.log_id,
+      display_name: 'Google Bar',
+      name_source: 'google',
+      attributions: [],
+    })))
+    getLog.mockReset()
+  })
+
+  it('resolves the store name without waiting for the row to become visible', async () => {
+    getLog.mockResolvedValue(record({ name: '', place_id: 'place-1' }))
+
+    const wrapper = await mountDetail()
+
+    expect(resolvePlaces).toHaveBeenCalledWith([{ log_id: 'log-1', place_id: 'place-1' }])
+    await nextTick()
+    expect(wrapper.text()).toContain('Google Bar')
+    wrapper.unmount()
+  })
+
+  it('does not spend a Places call when the user already named the store', async () => {
+    getLog.mockResolvedValue(record({ name: 'いつものバー', place_id: 'place-1' }))
+
+    const wrapper = await mountDetail()
+
+    expect(resolvePlaces).not.toHaveBeenCalled()
+    expect(wrapper.text()).toContain('いつものバー')
+    wrapper.unmount()
+  })
+
+  it('does not spend a Places call when there is no place reference', async () => {
+    getLog.mockResolvedValue(record({ name: '' }))
+
+    const wrapper = await mountDetail()
+
+    expect(resolvePlaces).not.toHaveBeenCalled()
+    expect(wrapper.text()).toContain('場所未登録')
+    wrapper.unmount()
+  })
+})


### PR DESCRIPTION
## 調査の経緯

#26 の実機確認中、店名未入力＋`place_id` の記録が詳細でもタイムラインでも「場所登録済み」のまま解決されないのを観測した。

切り分けの結果:

| 確認 | 結果 |
|---|---|
| API Gateway に `POST /api/drink-logs/places/resolve` | **存在する** |
| `drink-log-places-dev` への resolve 呼び出し（過去30日） | **0件** |
| ブラウザの `fetch` を計装 | 詳細画面の `GET` のみ。resolve は**発行されていない** |
| 同じ要素に自前の IntersectionObserver を張る | **一度も発火しない** |
| `document.visibilityState` | **`hidden`** |

**Chrome は非表示タブに交差エントリを配信しない。** 自動操作タブが常にバックグラウンドだったため観測できていなかった、というのが直接の理由で、アプリ側の配線自体は正しい（実ページをマウントするテストで observe → resolve を確認済み）。

## それでも直す理由

詳細画面は**レコード1件しか表示しない**。遅延しても Places 呼び出しは1回のままで、節約になっていない。一方で交差が届かない環境ではプレースホルダから永久に進まない。得の無い遅延で、詰む経路だけが残っている。

## 変更

- 詳細画面はレコード取得直後に `enqueue` する（`register` / `:ref` は削除）
- 店名が入力済み、または `place_id` が無い場合は**呼び出さない**（Places の上限を無駄に消費しない）
- **タイムラインは遅延解決のまま**。こちらは件数が読めないため、可視分だけ解決する設計に意味がある

## テスト

この配線は `expect(source).toContain(...)` のソース文字列テストしか無く、実際にマウントして解決を検証するものが無かった。追加した3ケース:

- **交差を一度も発火させない `IntersectionObserver` スタブ**（非表示タブの再現）でも店名が解決されること
- 店名が入力済みなら Places を呼ばないこと
- `place_id` が無ければ Places を呼ばないこと

1つ目は修正前の実装では**失敗する**ことを確認済み（vacuous でない）。

## 検証

`npm run lint` / `npm run typecheck` / `npx vitest run`（22ファイル・**151テスト**）/ `npm run generate` 全通過。`lambda/` `infra/` は無変更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FURbntamSSzLGDvU4rUVYG