### PR TITLE
feat(eval): 採点の主軸をブランドへ移す

### DIFF
--- a/docs/LLM_QUALITY.md
+++ b/docs/LLM_QUALITY.md
@@ -24,8 +24,18 @@ IAMステートメントは`infra/lib/bedrock-models.ts`の`bedrockInvokeStateme
 
 ## 測定する指標
 
-`scripts/eval/run_brand_eval.py`の既存`score_evaluation`と集計結果をそのまま使います。
-新しい指標は追加しません。
+主指標はブランド / 蒸留所層、副次指標はエクスプレッション層です。
+ボトルの商品名や熟成年数、カスク違いなどのエクスプレッションは無限に増え続けるため、カタログを完成させることはできません。
+そのためエクスプレッションIDだけで採点すると、モデルの読字力よりカタログの網羅性を強く測ってしまいます。
+
+ブランド層では、マニフェストの`expected_brand_key`と先頭候補の`brand_key`を比較します。
+
+* Brand confirmed correct / Brand confirmed wrong / Brand not confirmed（主指標）
+  * 先頭候補のブランドが正解 / 不正解 / ブランドなしのどれだったかを分割します。
+  * 正解率、誤確定率、未確定率を全体と撮影条件ごとに出します。
+  * `expected_brand_key: null`は「正解不明」なのでブランド指標の分母から除外し、除外件数を別に表示します。
+
+エクスプレッション層はカタログ命中率を見る副次指標として、既存のキーと計算を維持します。
 
 * Confirmed correct / Confirmed wrong / Not confirmed
   * 先頭候補が正解ID / 不正解ID / IDなしのどれだったかを全ケースで分割します。
@@ -40,7 +50,8 @@ IAMステートメントは`infra/lib/bedrock-models.ts`の`bedrockInvokeStateme
 * Rejection rate / No candidates rate
   * どの候補にもIDがないケースと、候補自体が空だったケースを分けた診断値です。
 
-全体と撮影条件ごとの集計に加えて、誤確定したケースの画像名 / 正解 / 実際の候補も結果JSONに残ります。
+ブランド層とエクスプレッション層のどちらも、全体と撮影条件ごとに集計します。
+エクスプレッションを誤確定したケースの画像名 / 正解 / 実際の候補も結果JSONに残ります。
 HTTPエラーなどで採点できなかった件数はattempted / scored / error casesで確認します。
 
 ## 実写真の準備
@@ -92,6 +103,23 @@ AWS_PROFILE=dev python scripts/eval/run_brand_eval.py scripts/eval/images-real \
 写真を見て`expected_canonical_name` / `expected_whiskey_id` / `condition` / `notes`を直し、確認済みのケースだけ`needs_review: false`に変更します。
 1件でもtrueが残っていると採点は始まりません。
 既存の`--emit-manifest`出力はレビュー済みラベルを保護するため上書きされません。意図的に下書きを作り直す場合だけ`--force`を追加してください。
+
+`expected_canonical_name`のレビュー後、ローカルの`scripts/catalog/brands.json`から`expected_brand_key`の提案を作ります。
+この処理はAWSを呼びません。
+既存マニフェストを更新するため、レビュー済みラベルの誤消去を防ぐ`--force`が必須です。
+
+```bash
+python scripts/eval/run_brand_eval.py \
+  --propose-brand-keys scripts/eval/manifest.real.json --force
+```
+
+正規化後の銘柄名が`brand_ja` / `brand_en` / `distillery_ja` / `distillery_en` / `aliases`のどれかと部分一致し、候補が1ブランドだけなら`expected_brand_key`を書き込みます。
+一致なし、または複数ブランドに一致したケースは`null`にして、`notes`へ`要確認: ブランドを特定できませんでした`を追記します。
+この処理は`expected_brand_key`列を**全ケース作り直します**。既に人が確認した値も対象で、カタログの変化で曖昧になれば`null`へ戻ります。一部だけを埋める用途には使えません。
+標準出力のケース一覧と写真を照合し、提案値と未決定ケースを人が確認してください。
+
+採点時はマニフェストに保存された`expected_brand_key`だけを正解として使い、カタログから再導出しません。
+したがって、後からカタログを変更しても同じマニフェストの正解は変わりません。
 
 確認後はローカル検査を通します。
 

--- a/scripts/eval/manifest.real.json
+++ b/scripts/eval/manifest.real.json
@@ -2,6 +2,7 @@
   "cases": [
     {
       "condition": "bottle_front",
+      "expected_brand_key": "laphroaig",
       "expected_canonical_name": "ラフロイグ 10年",
       "expected_whiskey_id": "laphroaig-10",
       "image": "images-real/01b332e69243e027.jpg",
@@ -10,6 +11,7 @@
     },
     {
       "condition": "bottle_front",
+      "expected_brand_key": "yuza",
       "expected_canonical_name": "YUZA spring in Japan 2024",
       "expected_whiskey_id": null,
       "image": "images-real/041b1c4f173bff70.jpg",
@@ -18,6 +20,7 @@
     },
     {
       "condition": "bottle_front",
+      "expected_brand_key": "glenlivet",
       "expected_canonical_name": "ザ・グレンリベット 12年",
       "expected_whiskey_id": null,
       "image": "images-real/11d4823dd468bcec.jpg",
@@ -26,6 +29,7 @@
     },
     {
       "condition": "bottle_front",
+      "expected_brand_key": "yamazaki",
       "expected_canonical_name": "山崎",
       "expected_whiskey_id": null,
       "image": "images-real/1f67c86dd63c7a21.jpg",
@@ -34,6 +38,7 @@
     },
     {
       "condition": "bottle_front",
+      "expected_brand_key": "loch_lomond",
       "expected_canonical_name": "ロッホ・ローモンド インチファッド 2005 17年",
       "expected_whiskey_id": null,
       "image": "images-real/22f2a30262771576.jpg",
@@ -42,6 +47,7 @@
     },
     {
       "condition": "bottle_front",
+      "expected_brand_key": "glenfiddich",
       "expected_canonical_name": "グレンフィディック 12年",
       "expected_whiskey_id": "glenfiddich-12",
       "image": "images-real/3742e77a84041a77.jpg",
@@ -50,6 +56,7 @@
     },
     {
       "condition": "bottle_front",
+      "expected_brand_key": "arran",
       "expected_canonical_name": "マクリームーア カスクストレングス",
       "expected_whiskey_id": null,
       "image": "images-real/38871b3bbcccd8e7.jpg",
@@ -58,6 +65,7 @@
     },
     {
       "condition": "bottle_front",
+      "expected_brand_key": "caol_ila",
       "expected_canonical_name": "カリラ 12年",
       "expected_whiskey_id": "caol-ila-12",
       "image": "images-real/3bbf60f2dbcc1f2b.jpg",
@@ -66,6 +74,7 @@
     },
     {
       "condition": "bottle_front",
+      "expected_brand_key": "ichiros_malt",
       "expected_canonical_name": "イチローズモルト ミズナラウッドリザーブ",
       "expected_whiskey_id": null,
       "image": "images-real/473287f93db7f784.jpg",
@@ -74,6 +83,7 @@
     },
     {
       "condition": "bottle_front",
+      "expected_brand_key": "caol_ila",
       "expected_canonical_name": "カリラ 12年",
       "expected_whiskey_id": "caol-ila-12",
       "image": "images-real/58f391f66188cf5b.jpg",
@@ -82,6 +92,7 @@
     },
     {
       "condition": "bottle_front",
+      "expected_brand_key": "port_charlotte",
       "expected_canonical_name": "ポートシャーロット　アイラバーレイ 2014",
       "expected_whiskey_id": null,
       "image": "images-real/5d293c8f7c4ed574.jpg",
@@ -90,6 +101,7 @@
     },
     {
       "condition": "bottle_front",
+      "expected_brand_key": "kilchoman",
       "expected_canonical_name": "キルホーマン マキヤーベイ",
       "expected_whiskey_id": null,
       "image": "images-real/5f44e5b8fbed3979.jpg",
@@ -98,6 +110,7 @@
     },
     {
       "condition": "bottle_front",
+      "expected_brand_key": "macallan",
       "expected_canonical_name": "ザ・マッカラン 12年 シェリーオークカスク",
       "expected_whiskey_id": null,
       "image": "images-real/777ab5b0688e3766.jpg",
@@ -106,6 +119,7 @@
     },
     {
       "condition": "bottle_front",
+      "expected_brand_key": "shizuoka",
       "expected_canonical_name": "静岡 ポットスティルＫ 純外国産大麦",
       "expected_whiskey_id": null,
       "image": "images-real/7acde4517afaf1f2.jpg",
@@ -114,6 +128,7 @@
     },
     {
       "condition": "bottle_front",
+      "expected_brand_key": "arran",
       "expected_canonical_name": "アラン 10年",
       "expected_whiskey_id": null,
       "image": "images-real/7e7a48fc30343313.jpg",
@@ -122,6 +137,7 @@
     },
     {
       "condition": "bottle_front",
+      "expected_brand_key": "bunnahabhain",
       "expected_canonical_name": "ブナハーブン 12年",
       "expected_whiskey_id": "bunnahabhain-12",
       "image": "images-real/86043967443bceb5.jpg",
@@ -130,6 +146,7 @@
     },
     {
       "condition": "bottle_front",
+      "expected_brand_key": "fuji",
       "expected_canonical_name": "富士山麓 シグニチャーブレンド",
       "expected_whiskey_id": null,
       "image": "images-real/86d37188fdd388ea.jpg",
@@ -138,6 +155,7 @@
     },
     {
       "condition": "bottle_front",
+      "expected_brand_key": "taketsuru",
       "expected_canonical_name": "竹鶴 ピュアモルト",
       "expected_whiskey_id": "taketsuru-pure-malt",
       "image": "images-real/9d9b513092ea8d0b.jpg",
@@ -146,6 +164,7 @@
     },
     {
       "condition": "bottle_front",
+      "expected_brand_key": "laphroaig",
       "expected_canonical_name": "ラフロイグ 10年",
       "expected_whiskey_id": "laphroaig-10",
       "image": "images-real/a181cb9ea5fb45fe.jpg",
@@ -154,6 +173,7 @@
     },
     {
       "condition": "bottle_front",
+      "expected_brand_key": "otani",
       "expected_canonical_name": "大谷ウイスキー 新潟亀田 ゾディアック サイン シリーズ 「Piscas」",
       "expected_whiskey_id": null,
       "image": "images-real/aea286cf1b65a8d1.jpg",
@@ -162,6 +182,7 @@
     },
     {
       "condition": "bottle_front",
+      "expected_brand_key": "hibiki",
       "expected_canonical_name": "響 ブレンダーズチョイス",
       "expected_whiskey_id": null,
       "image": "images-real/c63c9dd7233f1a85.jpg",
@@ -170,6 +191,7 @@
     },
     {
       "condition": "bottle_front",
+      "expected_brand_key": "port_charlotte",
       "expected_canonical_name": "ポートシャーロット 10年",
       "expected_whiskey_id": null,
       "image": "images-real/c88e636e4b997979.jpg",
@@ -178,6 +200,7 @@
     },
     {
       "condition": "bottle_front",
+      "expected_brand_key": "ichiros_malt",
       "expected_canonical_name": "イチローズモルト ダブルディスティラリーズ",
       "expected_whiskey_id": null,
       "image": "images-real/c8ab63402874f242.jpg",
@@ -186,6 +209,7 @@
     },
     {
       "condition": "bottle_front",
+      "expected_brand_key": "sakurao",
       "expected_canonical_name": "桜尾 シングルモルト",
       "expected_whiskey_id": null,
       "image": "images-real/d9226c34aa7c7be1.jpg",
@@ -194,6 +218,7 @@
     },
     {
       "condition": "bottle_front",
+      "expected_brand_key": "ardbeg",
       "expected_canonical_name": "アードベッグ 10年",
       "expected_whiskey_id": null,
       "image": "images-real/e6cfec68c8bc3397.jpg",
@@ -202,6 +227,7 @@
     },
     {
       "condition": "bottle_front",
+      "expected_brand_key": "lagavulin",
       "expected_canonical_name": "ラガヴーリン 16年",
       "expected_whiskey_id": "lagavulin-16",
       "image": "images-real/f5ea380cfb8782f2.jpg",
@@ -210,6 +236,7 @@
     },
     {
       "condition": "bottle_front",
+      "expected_brand_key": "akkeshi",
       "expected_canonical_name": "厚岸 シングルモルト ジャパニーズ ウイスキー -立春-",
       "expected_whiskey_id": null,
       "image": "images-real/feddadf4ebc40d8b.jpg",

--- a/scripts/eval/manifest.schema.json
+++ b/scripts/eval/manifest.schema.json
@@ -64,6 +64,13 @@
           ],
           "minLength": 1
         },
+        "expected_brand_key": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1
+        },
         "notes": {
           "type": "string"
         },

--- a/scripts/eval/run_brand_eval.py
+++ b/scripts/eval/run_brand_eval.py
@@ -14,6 +14,7 @@ import mimetypes
 import os
 import re
 import sys
+import unicodedata
 import uuid
 from collections import Counter
 from datetime import datetime, timezone
@@ -63,9 +64,14 @@ CASE_REQUIRED_FIELDS = {
     "expected_whiskey_id",
     "expected_canonical_name",
 }
-CASE_ALLOWED_FIELDS = CASE_REQUIRED_FIELDS | {"notes", "needs_review"}
+CASE_ALLOWED_FIELDS = CASE_REQUIRED_FIELDS | {
+    "expected_brand_key",
+    "notes",
+    "needs_review",
+}
 DRAFT_CONDITION = "bottle_front"
 DRAFT_NOTES = "要確認: 撮影条件を実際の写真に合わせて修正すること"
+BRAND_REVIEW_NOTE = "要確認: ブランドを特定できませんでした"
 EVAL_USER_RE = re.compile(r"^[A-Za-z0-9._:@+-]+$")
 CLIENT_CONFIG = Config(
     connect_timeout=5,
@@ -73,6 +79,7 @@ CLIENT_CONFIG = Config(
     retries={"mode": "standard", "total_max_attempts": 2},
 )
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+BRANDS_PATH = REPOSITORY_ROOT / "scripts/catalog/brands.json"
 
 
 class ManifestError(ValueError):
@@ -165,6 +172,13 @@ def validate_manifest_data(data: Any) -> dict[str, Any]:
         if whiskey_id is not None and canonical_name is None:
             raise ManifestError(
                 f"{location}.expected_canonical_name is required for a catalog whiskey"
+            )
+        brand_key = case.get("expected_brand_key")
+        if brand_key is not None and (
+            not isinstance(brand_key, str) or not brand_key.strip()
+        ):
+            raise ManifestError(
+                f"{location}.expected_brand_key must be a non-empty string or null"
             )
         if "notes" in case and not isinstance(case["notes"], str):
             raise ManifestError(f"{location}.notes must be a string")
@@ -270,6 +284,13 @@ def _candidate_id(candidate: Any) -> str | None:
     return value if isinstance(value, str) and value else None
 
 
+def _candidate_brand_key(candidate: Any) -> str | None:
+    if not isinstance(candidate, Mapping):
+        return None
+    value = candidate.get("brand_key")
+    return value if isinstance(value, str) and value else None
+
+
 def score_evaluation(record: Mapping[str, Any]) -> dict[str, Any]:
     """Score one response using a top-candidate confirmation partition."""
     case = record["case"]
@@ -278,7 +299,9 @@ def score_evaluation(record: Mapping[str, Any]) -> dict[str, Any]:
     if not isinstance(candidates, list):
         candidates = []
     expected_id = case["expected_whiskey_id"]
+    expected_brand_key = case.get("expected_brand_key")
     top_id = _candidate_id(candidates[0]) if candidates else None
+    actual_brand_key = _candidate_brand_key(candidates[0]) if candidates else None
     confirmed = top_id is not None
     confirmed_correct = confirmed and top_id == expected_id
     confirmed_wrong = confirmed and top_id != expected_id
@@ -291,7 +314,20 @@ def score_evaluation(record: Mapping[str, Any]) -> dict[str, Any]:
     rejected = not any(_candidate_id(candidate) is not None for candidate in candidates)
     no_candidates = not candidates
     top = candidates[0] if candidates and isinstance(candidates[0], Mapping) else {}
+    # Gate the verdicts on having a truth value at all. The aggregator already
+    # excludes these cases, but a per-case reader (the way false_confirmation_cases
+    # reads its flag) would otherwise report "we don't know" as "the model was wrong".
+    brand_evaluable = expected_brand_key is not None
     return {
+        "brand_evaluable": brand_evaluable,
+        "brand_confirmed_correct": (
+            brand_evaluable and actual_brand_key is not None and actual_brand_key == expected_brand_key
+        ),
+        "brand_confirmed_wrong": (
+            brand_evaluable and actual_brand_key is not None and actual_brand_key != expected_brand_key
+        ),
+        "brand_not_confirmed": brand_evaluable and actual_brand_key is None,
+        "actual_brand_key": actual_brand_key,
         "confirmed_correct": confirmed_correct,
         "confirmed_wrong": confirmed_wrong,
         "not_confirmed": not_confirmed,
@@ -337,6 +373,22 @@ def _aggregate_records(records: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
     ]
     retrievable_total = len(retrievable)
     unanswerable_total = len(unanswerable)
+    brand_evaluable = [
+        score
+        for score, record in zip(scores, scored_records)
+        if record["case"].get("expected_brand_key") is not None
+    ]
+    brand_evaluable_total = len(brand_evaluable)
+    brand_excluded_total = total - brand_evaluable_total
+    brand_confirmed_correct = sum(
+        score["brand_confirmed_correct"] for score in brand_evaluable
+    )
+    brand_confirmed_wrong = sum(
+        score["brand_confirmed_wrong"] for score in brand_evaluable
+    )
+    brand_not_confirmed = sum(
+        score["brand_not_confirmed"] for score in brand_evaluable
+    )
     top1 = sum(score["top1_correct"] for score in retrievable)
     top3 = sum(score["top3_correct"] for score in retrievable)
     confirmed_correct = sum(score["confirmed_correct"] for score in scores)
@@ -351,6 +403,20 @@ def _aggregate_records(records: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
     correct_abstentions = sum(score["not_confirmed"] for score in unanswerable)
     return {
         "cases": total,
+        "brand_evaluable_cases": brand_evaluable_total,
+        "brand_excluded_cases": brand_excluded_total,
+        "brand_confirmed_correct": brand_confirmed_correct,
+        "brand_confirmed_correct_rate": _rate(
+            brand_confirmed_correct, brand_evaluable_total
+        ),
+        "brand_confirmed_wrong": brand_confirmed_wrong,
+        "brand_confirmed_wrong_rate": _rate(
+            brand_confirmed_wrong, brand_evaluable_total
+        ),
+        "brand_not_confirmed": brand_not_confirmed,
+        "brand_not_confirmed_rate": _rate(
+            brand_not_confirmed, brand_evaluable_total
+        ),
         "retrievable_cases": retrievable_total,
         "unanswerable_cases": unanswerable_total,
         "confirmed_correct": confirmed_correct,
@@ -485,8 +551,51 @@ def _metric_row(label: str, aggregate: Mapping[str, Any]) -> list[str]:
     ]
 
 
+def _brand_metric_row(label: str, aggregate: Mapping[str, Any]) -> list[str]:
+    evaluable = aggregate["brand_evaluable_cases"]
+    return [
+        label,
+        str(aggregate["cases"]),
+        str(evaluable),
+        str(aggregate["brand_excluded_cases"]),
+        format_rate(
+            aggregate["brand_confirmed_correct"],
+            evaluable,
+            aggregate["brand_confirmed_correct_rate"],
+        ),
+        format_rate(
+            aggregate["brand_confirmed_wrong"],
+            evaluable,
+            aggregate["brand_confirmed_wrong_rate"],
+        ),
+        format_rate(
+            aggregate["brand_not_confirmed"],
+            evaluable,
+            aggregate["brand_not_confirmed_rate"],
+        ),
+    ]
+
+
 def print_metrics_report(metrics: Mapping[str, Any]) -> None:
     """Print overall metrics, condition metrics, and false confirmations."""
+    brand_headers = (
+        "Scope",
+        "Cases",
+        "Brand denominator",
+        "Brand excluded",
+        "Brand correct",
+        "Brand wrong",
+        "Brand not confirmed",
+    )
+    print("\nBrand metrics (primary) - Overall")
+    print(_format_table(brand_headers, [_brand_metric_row("ALL", metrics["overall"])]))
+    print("\nBrand metrics (primary) - By condition")
+    brand_condition_rows = [
+        _brand_metric_row(condition, aggregate)
+        for condition, aggregate in metrics["by_condition"].items()
+    ]
+    print(_format_table(brand_headers, brand_condition_rows))
+
     headers = (
         "Scope",
         "Cases",
@@ -501,9 +610,9 @@ def print_metrics_report(metrics: Mapping[str, Any]) -> None:
         "Rejection (diagnostic)",
         "No candidates (diagnostic)",
     )
-    print("\nOverall")
+    print("\nExpression metrics (secondary) - Overall")
     print(_format_table(headers, [_metric_row("ALL", metrics["overall"])]))
-    print("\nBy condition")
+    print("\nExpression metrics (secondary) - By condition")
     condition_rows = [
         _metric_row(condition, aggregate)
         for condition, aggregate in metrics["by_condition"].items()
@@ -657,6 +766,127 @@ def save_manifest_draft_atomic(
     """Write a draft without silently replacing possible reviewed labels."""
     ensure_manifest_output_available(path, force=force)
     save_json_atomic(path, document)
+
+
+def normalize_brand_label(value: str) -> str:
+    """Normalize a catalog or manifest label for local partial matching."""
+    normalized = unicodedata.normalize("NFKC", value).casefold()
+    return "".join(character for character in normalized if character.isalnum())
+
+
+def load_brand_catalog(path: Path | None = None) -> list[dict[str, Any]]:
+    """Load the local version 1 brand catalog without using AWS."""
+    catalog_path = path or BRANDS_PATH
+    with catalog_path.open(encoding="utf-8") as catalog_file:
+        document = json.load(catalog_file)
+    if not isinstance(document, dict) or document.get("version") != 1:
+        raise ValueError("brands catalog must be a version 1 JSON object")
+    brands = document.get("brands")
+    if not isinstance(brands, list):
+        raise ValueError("brands catalog must contain a brands array")
+    for index, brand in enumerate(brands):
+        if not isinstance(brand, dict):
+            raise ValueError(f"brands[{index}] must be an object")
+        brand_key = brand.get("brand_key")
+        if not isinstance(brand_key, str) or not brand_key.strip():
+            raise ValueError(f"brands[{index}].brand_key must be a non-empty string")
+    return brands
+
+
+def _brand_match_keys(
+    canonical_name: Any,
+    brands: Sequence[Mapping[str, Any]],
+) -> set[str]:
+    if not isinstance(canonical_name, str):
+        return set()
+    normalized_canonical_name = normalize_brand_label(canonical_name)
+    if not normalized_canonical_name:
+        return set()
+
+    matches: set[str] = set()
+    for brand in brands:
+        raw_names = [
+            brand.get("brand_ja"),
+            brand.get("brand_en"),
+            brand.get("distillery_ja"),
+            brand.get("distillery_en"),
+        ]
+        aliases = brand.get("aliases", [])
+        if isinstance(aliases, list):
+            raw_names.extend(aliases)
+        for raw_name in raw_names:
+            if not isinstance(raw_name, str):
+                continue
+            normalized_name = normalize_brand_label(raw_name)
+            if normalized_name and (
+                normalized_name in normalized_canonical_name
+                or normalized_canonical_name in normalized_name
+            ):
+                matches.add(brand["brand_key"])
+                break
+    return matches
+
+
+def _append_brand_review_note(case: dict[str, Any]) -> None:
+    notes = case.get("notes", "")
+    if BRAND_REVIEW_NOTE in notes:
+        return
+    separator = "" if not notes or notes.endswith("\n") else "\n"
+    case["notes"] = f"{notes}{separator}{BRAND_REVIEW_NOTE}"
+
+
+def propose_brand_keys(
+    manifest: Mapping[str, Any],
+    brands: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Return a manifest with only uniquely matched brand keys proposed."""
+    proposed = {
+        "version": manifest["version"],
+        "cases": [dict(case) for case in manifest["cases"]],
+    }
+    for case in proposed["cases"]:
+        matches = _brand_match_keys(case.get("expected_canonical_name"), brands)
+        if len(matches) == 1:
+            case["expected_brand_key"] = next(iter(matches))
+        else:
+            case["expected_brand_key"] = None
+            _append_brand_review_note(case)
+    return validate_manifest_data(proposed)
+
+
+def print_brand_key_proposals(manifest: Mapping[str, Any]) -> None:
+    """Print every proposed brand label for human review."""
+    rows = [
+        [
+            str(index),
+            str(case.get("expected_canonical_name") or "-"),
+            str(case.get("expected_brand_key") or "未決定"),
+        ]
+        for index, case in enumerate(manifest["cases"])
+    ]
+    print(_format_table(("Case", "Canonical name", "brand_key"), rows))
+
+
+def propose_brand_keys_file(
+    manifest_path: Path,
+    *,
+    force: bool,
+    brands_path: Path | None = None,
+) -> dict[str, Any]:
+    """Propose labels into an existing manifest using only local JSON files."""
+    ensure_manifest_output_available(manifest_path, force=force)
+    try:
+        with manifest_path.open(encoding="utf-8") as manifest_file:
+            raw_manifest = json.load(manifest_file)
+    except json.JSONDecodeError as exc:
+        raise ManifestError(f"manifest is not valid JSON: {exc}") from exc
+    manifest = validate_manifest_data(raw_manifest)
+    proposed = propose_brand_keys(
+        manifest,
+        load_brand_catalog(brands_path),
+    )
+    save_json_atomic(manifest_path, proposed)
+    return proposed
 
 
 def repository_relative_path(path: Path) -> str:
@@ -1101,12 +1331,19 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Evaluate whiskey brand recognition")
     parser.add_argument(
         "input",
+        nargs="?",
         type=Path,
         help="manifest path, or an image directory with --emit-manifest",
     )
     mode = parser.add_mutually_exclusive_group(required=True)
     mode.add_argument("--target", choices=("dev",))
     mode.add_argument("--dry-run", action="store_true")
+    mode.add_argument(
+        "--propose-brand-keys",
+        type=Path,
+        metavar="MANIFEST",
+        help="locally propose expected_brand_key values into a manifest",
+    )
     parser.add_argument("--profile", help="explicit AWS profile required for --target dev")
     parser.add_argument(
         "--aud",
@@ -1125,7 +1362,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--force",
         action="store_true",
-        help="replace an existing --emit-manifest output",
+        help="replace an existing manifest output",
     )
     return parser.parse_args(argv)
 
@@ -1171,6 +1408,20 @@ def main(argv: list[str] | None = None) -> int:
     """Run local validation or the guarded dev evaluation."""
     args = parse_args(argv)
     try:
+        if args.propose_brand_keys is not None:
+            if args.input is not None:
+                raise ValueError(
+                    "the positional input is not used with --propose-brand-keys"
+                )
+            proposed = propose_brand_keys_file(
+                args.propose_brand_keys,
+                force=args.force,
+            )
+            print_brand_key_proposals(proposed)
+            return 0
+
+        if args.input is None:
+            raise ValueError("a manifest path or image directory is required")
         if args.emit_manifest is not None:
             if args.dry_run:
                 raise ValueError("--emit-manifest requires --target dev")

--- a/tests/eval/test_run_brand_eval.py
+++ b/tests/eval/test_run_brand_eval.py
@@ -88,6 +88,14 @@ def test_calculate_metrics_uses_top_candidate_partition_and_separate_denominator
 
     assert overall == {
         "cases": 5,
+        "brand_evaluable_cases": 0,
+        "brand_excluded_cases": 5,
+        "brand_confirmed_correct": 0,
+        "brand_confirmed_correct_rate": None,
+        "brand_confirmed_wrong": 0,
+        "brand_confirmed_wrong_rate": None,
+        "brand_not_confirmed": 0,
+        "brand_not_confirmed_rate": None,
         "retrievable_cases": 4,
         "unanswerable_cases": 1,
         "confirmed_correct": 1,
@@ -113,6 +121,103 @@ def test_calculate_metrics_uses_top_candidate_partition_and_separate_denominator
     }
     assert metrics["by_condition"]["bottle_front"]["top3_correct"] == 2
     assert metrics["by_condition"]["bottle_angle"]["rejections"] == 1
+
+
+def test_brand_score_classifies_correct_wrong_and_not_confirmed():
+    case = _case("bottle_front", "expression")
+    case["expected_brand_key"] = "expected-brand"
+    records = [
+        _record(0, case, [{"brand_key": "expected-brand"}]),
+        _record(1, case, [{"brand_key": "different-brand"}]),
+        _record(2, case, [{"brand_text": "unresolved"}]),
+    ]
+
+    correct, wrong, not_confirmed = map(brand_eval.score_evaluation, records)
+
+    assert correct["brand_confirmed_correct"] is True
+    assert correct["brand_confirmed_wrong"] is False
+    assert correct["brand_not_confirmed"] is False
+    assert correct["actual_brand_key"] == "expected-brand"
+    assert wrong["brand_confirmed_correct"] is False
+    assert wrong["brand_confirmed_wrong"] is True
+    assert wrong["brand_not_confirmed"] is False
+    assert wrong["actual_brand_key"] == "different-brand"
+    assert not_confirmed["brand_confirmed_correct"] is False
+    assert not_confirmed["brand_confirmed_wrong"] is False
+    assert not_confirmed["brand_not_confirmed"] is True
+    assert not_confirmed["actual_brand_key"] is None
+    aggregate = brand_eval.calculate_metrics(records)["overall"]
+    assert aggregate["brand_confirmed_correct"] == 1
+    assert aggregate["brand_confirmed_wrong"] == 1
+    assert aggregate["brand_not_confirmed"] == 1
+    assert aggregate["brand_confirmed_correct_rate"] == pytest.approx(1 / 3)
+    assert aggregate["brand_confirmed_wrong_rate"] == pytest.approx(1 / 3)
+    assert aggregate["brand_not_confirmed_rate"] == pytest.approx(1 / 3)
+
+
+def test_null_expected_brand_key_is_excluded_from_brand_denominator():
+    known = _case("bottle_front", "known-expression")
+    known["expected_brand_key"] = "known-brand"
+    unknown = _case("bottle_front", None)
+    unknown["expected_brand_key"] = None
+    records = [
+        _record(0, known, [{"brand_key": "known-brand"}]),
+        _record(1, unknown, [{"brand_key": "any-brand"}]),
+    ]
+
+    overall = brand_eval.calculate_metrics(records)["overall"]
+
+    assert overall["cases"] == 2
+    assert overall["brand_evaluable_cases"] == 1
+    assert overall["brand_excluded_cases"] == 1
+    assert overall["brand_confirmed_correct"] == 1
+    assert overall["brand_confirmed_correct_rate"] == pytest.approx(1.0)
+    assert overall["brand_confirmed_wrong"] == 0
+    assert overall["brand_not_confirmed"] == 0
+    by_condition = brand_eval.calculate_metrics(records)["by_condition"]["bottle_front"]
+    assert by_condition["brand_evaluable_cases"] == 1
+    assert by_condition["brand_excluded_cases"] == 1
+
+
+def test_existing_expression_score_values_are_unchanged_when_brand_is_scored():
+    assert brand_eval.RESULT_VERSION == 1
+    case = _case("bottle_front", "expression-id")
+    case["expected_brand_key"] = "brand-a"
+    score = brand_eval.score_evaluation(
+        _record(
+            0,
+            case,
+            [
+                {"whiskey_id": "wrong-id", "brand_key": "brand-a"},
+                {"whiskey_id": "expression-id"},
+            ],
+        )
+    )
+
+    assert {
+        key: score[key]
+        for key in (
+            "confirmed_correct",
+            "confirmed_wrong",
+            "not_confirmed",
+            "top1_correct",
+            "top3_correct",
+            "false_confirmation",
+            "rejected",
+            "no_candidates",
+            "actual_whiskey_id",
+        )
+    } == {
+        "confirmed_correct": False,
+        "confirmed_wrong": True,
+        "not_confirmed": False,
+        "top1_correct": False,
+        "top3_correct": True,
+        "false_confirmation": True,
+        "rejected": False,
+        "no_candidates": False,
+        "actual_whiskey_id": "wrong-id",
+    }
 
 
 def test_unresolved_top_candidate_with_resolved_second_candidate_is_not_confirmed():
@@ -235,12 +340,194 @@ def test_manifest_validation_accepts_uppercase_image_extension():
     assert brand_eval.validate_manifest_data(manifest) == manifest
 
 
+def test_manifest_validation_accepts_expected_brand_key():
+    case = _case("bottle_front", "a")
+    case["expected_brand_key"] = "brand-a"
+    manifest = {"version": 1, "cases": [case]}
+
+    assert brand_eval.validate_manifest_data(manifest) == manifest
+    case["expected_brand_key"] = None
+    assert brand_eval.validate_manifest_data(manifest) == manifest
+
+
+@pytest.mark.parametrize("invalid", [123, True, ""])
+def test_manifest_validation_rejects_invalid_expected_brand_key(invalid):
+    case = _case("bottle_front", "a")
+    case["expected_brand_key"] = invalid
+
+    with pytest.raises(brand_eval.ManifestError, match="expected_brand_key"):
+        brand_eval.validate_manifest_data({"version": 1, "cases": [case]})
+
+
+def test_manifest_schema_accepts_expected_brand_key_and_rejects_wrong_type():
+    jsonschema = pytest.importorskip("jsonschema")
+    schema_path = Path(brand_eval.__file__).with_name("manifest.schema.json")
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    validator = jsonschema.Draft202012Validator(schema)
+    case = _case("bottle_front", "a")
+    case["expected_brand_key"] = "brand-a"
+
+    validator.validate({"version": 1, "cases": [case]})
+    case["expected_brand_key"] = None
+    validator.validate({"version": 1, "cases": [case]})
+    case["expected_brand_key"] = 123
+    with pytest.raises(jsonschema.ValidationError):
+        validator.validate({"version": 1, "cases": [case]})
+
+
 def test_manifest_validation_rejects_non_boolean_needs_review():
     case = _case("bottle_front", "a")
     case["needs_review"] = "false"
 
     with pytest.raises(brand_eval.ManifestError, match="needs_review must be a boolean"):
         brand_eval.validate_manifest_data({"version": 1, "cases": [case]})
+
+
+def test_propose_brand_keys_sets_only_unique_matches_and_marks_others():
+    brands = [
+        {
+            "brand_key": "alpha",
+            "brand_ja": "アルファ",
+            "brand_en": "Alpha",
+            "distillery_ja": "アルファ蒸留所",
+            "distillery_en": "Alpha Distillery",
+            "aliases": ["ALPHA"],
+        },
+        {
+            "brand_key": "shared-one",
+            "brand_ja": "共有一",
+            "aliases": ["Shared"],
+        },
+        {
+            "brand_key": "shared-two",
+            "brand_ja": "共有二",
+            "aliases": ["Shared"],
+        },
+    ]
+    unique = _case("bottle_front", None, "images/unique.jpg")
+    unique.update(
+        {
+            "expected_canonical_name": "Alpha 12 Year Old",
+            "notes": "reviewed note",
+        }
+    )
+    ambiguous = _case("bottle_front", None, "images/ambiguous.jpg")
+    ambiguous.update(
+        {
+            "expected_canonical_name": "Shared Reserve",
+            "notes": "keep this",
+        }
+    )
+    unmatched = _case("bottle_front", None, "images/unmatched.jpg")
+    unmatched["expected_canonical_name"] = "No Catalog Match"
+
+    proposed = brand_eval.propose_brand_keys(
+        {"version": 1, "cases": [unique, ambiguous, unmatched]},
+        brands,
+    )
+
+    assert proposed["cases"][0]["expected_brand_key"] == "alpha"
+    assert proposed["cases"][0]["notes"] == "reviewed note"
+    assert proposed["cases"][1]["expected_brand_key"] is None
+    assert proposed["cases"][1]["notes"] == (
+        f"keep this\n{brand_eval.BRAND_REVIEW_NOTE}"
+    )
+    assert proposed["cases"][2]["expected_brand_key"] is None
+    assert proposed["cases"][2]["notes"] == brand_eval.BRAND_REVIEW_NOTE
+
+
+def test_propose_brand_keys_rebuilds_reviewed_values_including_to_null():
+    """The proposer replaces the whole column; it does not fill gaps.
+
+    A value a human already confirmed is recomputed, and reverts to null when the
+    catalog no longer resolves it uniquely. Pinning this keeps the destructive
+    behaviour visible rather than incidental.
+    """
+    brands = [
+        {"brand_key": "shared_one", "brand_ja": "共有一", "aliases": ["Shared"]},
+        {"brand_key": "shared_two", "brand_ja": "共有二", "aliases": ["Shared"]},
+    ]
+    reviewed = _case("bottle_front", None, "images/reviewed.jpg")
+    reviewed.update(
+        {
+            "expected_canonical_name": "Shared Reserve",
+            "expected_brand_key": "confirmed_by_a_human",
+        }
+    )
+
+    proposed = brand_eval.propose_brand_keys({"version": 1, "cases": [reviewed]}, brands)
+
+    assert proposed["cases"][0]["expected_brand_key"] is None
+    assert brand_eval.BRAND_REVIEW_NOTE in proposed["cases"][0]["notes"]
+
+
+def test_zero_brand_denominator_renders_as_not_applicable():
+    """An empty denominator must never be printed as 0.0%."""
+    assert brand_eval.format_rate(0, 0, None) == "該当なし"
+    assert brand_eval.format_rate(0, 3, 0.0) != "該当なし"
+
+
+def test_propose_brand_keys_cli_requires_force_and_never_calls_aws(
+    tmp_path, monkeypatch, capsys
+):
+    manifest_path = tmp_path / "manifest.json"
+    case = _case("bottle_front", None)
+    case["expected_canonical_name"] = "Alpha Special"
+    original = json.dumps({"version": 1, "cases": [case]}).encode("utf-8")
+    manifest_path.write_bytes(original)
+    brands_path = tmp_path / "brands.json"
+    brands_path.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "brands": [
+                    {
+                        "brand_key": "alpha",
+                        "brand_ja": "アルファ",
+                        "brand_en": "Alpha",
+                        "aliases": [],
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(brand_eval, "BRANDS_PATH", brands_path)
+    monkeypatch.setattr(
+        brand_eval.boto3,
+        "Session",
+        lambda **_kwargs: pytest.fail("AWS session must not be created"),
+    )
+
+    assert brand_eval.main(["--propose-brand-keys", str(manifest_path)]) == 1
+    assert manifest_path.read_bytes() == original
+    assert "use --force" in capsys.readouterr().err
+
+    assert brand_eval.main(
+        ["--propose-brand-keys", str(manifest_path), "--force"]
+    ) == 0
+    proposed = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert proposed["cases"][0]["expected_brand_key"] == "alpha"
+    output = capsys.readouterr().out
+    assert "0" in output
+    assert "Alpha Special" in output
+    assert "alpha" in output
+
+
+def test_metrics_report_prints_brand_rates_overall_and_by_condition(capsys):
+    case = _case("bottle_front", "expression")
+    case["expected_brand_key"] = "alpha"
+    metrics = brand_eval.calculate_metrics(
+        [_record(0, case, [{"brand_key": "alpha", "whiskey_id": "expression"}])]
+    )
+
+    brand_eval.print_metrics_report(metrics)
+
+    output = capsys.readouterr().out
+    assert "Brand metrics (primary) - Overall" in output
+    assert "Brand metrics (primary) - By condition" in output
+    assert "Brand excluded" in output
+    assert "1/1 (100.0%)" in output
 
 
 def test_draft_manifest_matches_schema_and_marks_every_case_for_review(tmp_path):


### PR DESCRIPTION
Issue #25。#35 / #36 の続き。

## 背景

エクスプレッションIDだけで採点していたため、実写真27枚のうち**19件が「IDを確定しないのが正解」**として扱われていた。この評価セットはモデルの読字力ではなく**カタログの網羅性**を測っており、モデル比較の道具として機能していなかった。

| 層 | 採点対象 |
|---|---|
| エクスプレッション（従来） | 8/27 |
| **ブランド / 蒸留所** | **27/27** |

## 変更

- マニフェストに任意の `expected_brand_key` を追加。ブランド層の正解率・誤確定率・未確定率を**全体と撮影条件別**で出す
- エクスプレッション層の指標は**副次指標として維持**（値も `RESULT_VERSION` も不変）
- `--propose-brand-keys` でカタログから提案を生成（**AWSを呼ばない**）。一意のときだけ書き込み、曖昧なら `null` + `notes` に印。既存ファイルの上書きは `--force` 必須

## 物差しが嘘をつかないための2点

**① `expected_brand_key` が null のケースはブランド指標の分母から除外し、除外件数を出す。** 「正解が不明」と「正解が無い」を混同すれば、数字は簡単に嘘になる。

**② 正解は常にマニフェストの値だけを使い、採点時にカタログから再導出しない。** 導出方式にすると、カタログを直した瞬間に正解が変わる ― 物差しが、測る対象と一緒に動いてしまう。

## 27件のラベル

621が確認済みの `expected_canonical_name` は**1文字も変えていない**（27行の追加のみ、削除0）。全件が一意のブランドに解決した。マクリームーア→`arran`、大谷ウイスキー→`otani`、ポートシャーロット→`port_charlotte` など、レビュアーが独立に再計算して committed 値と一致することを確認済み。

## レビュー結果

**APPROVE**（重大・重要の指摘なし）。軽微3点のうち2点を反映:

- **ケース単位のブランド判定を `expected_brand_key` の有無でゲートした。** 集計側は除外していたが、ケース単位で読む利用者（`false_confirmation_cases` と同じ読み方）が**「正解不明」を「モデルの誤り」として報告しうる罠**だった。次の変更で踏む前に塞いだ
- `--propose-brand-keys` が列を**全件作り直す**（部分補完ではない）ことをドキュメントに明記

不足していたテスト2件も追加した。

## 検証

- `python -m pytest tests` → **326 passed**
- `git diff --stat -- lambda/ infra/ frontend/ scripts/catalog/` → **空**
- 依存追加なし（`unicodedata` は標準ライブラリ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FURbntamSSzLGDvU4rUVYG