### PR TITLE
chore: four small cleanups (dead alias, header dedupe, WEBP skips, path parity)

### DIFF
--- a/lambda/common/python/whiskey_common/jwt_utils.py
+++ b/lambda/common/python/whiskey_common/jwt_utils.py
@@ -107,6 +107,3 @@ def extract_user_id_from_event(event: Mapping[str, Any]) -> str | None:
         return None
     payload = verify_cognito_jwt(token)
     return payload.get("sub") if payload else None
-
-
-extract_user_id_from_token = extract_user_id_from_event

--- a/lambda/common/python/whiskey_common/responses.py
+++ b/lambda/common/python/whiskey_common/responses.py
@@ -48,8 +48,14 @@ def create_response(
     logger: Any = None,
 ) -> dict[str, Any]:
     """Create a valid API Gateway Lambda proxy response."""
-    response_headers = dict(headers or get_cors_headers(event or {}, private=private))
-    if private:
+    if headers:
+        response_headers = dict(headers)
+    else:
+        response_headers = get_cors_headers(event or {}, private=private)
+    # Only needed on the caller-supplied-headers path: the else branch above passes
+    # private=private into get_cors_headers, which already sets this. Keep that
+    # argument if you touch the branch, or private responses lose no-store here.
+    if private and headers:
         response_headers["Cache-Control"] = "private, no-store"
     response = {
         "statusCode": status_code,

--- a/local_api/main.py
+++ b/local_api/main.py
@@ -219,13 +219,17 @@ app.add_middleware(
 )
 
 
+@app.get("/api/whiskeys/")
 @app.get("/api/whiskeys")
 async def list_whiskeys(request: Request) -> Response:
     return await invoke(request, WHISKEY_LIST.lambda_handler)
 
 
+@app.get("/api/whiskeys/search/")
 @app.get("/api/whiskeys/search")
+@app.get("/api/whiskeys/suggest/")
 @app.get("/api/whiskeys/suggest")
+@app.get("/api/whiskeys/search/suggest/")
 @app.get("/api/whiskeys/search/suggest")
 async def search_whiskeys(request: Request) -> Response:
     return await invoke(request, WHISKEY_SEARCH.lambda_handler)

--- a/tests/lambda/test_drink_logs.py
+++ b/tests/lambda/test_drink_logs.py
@@ -13,7 +13,7 @@ import boto3
 import pytest
 from botocore.exceptions import ClientError
 from moto import mock_aws
-from PIL import Image
+from PIL import Image, features
 
 from tests.lambda_module_loader import load_lambda_module
 
@@ -25,6 +25,9 @@ images = load_lambda_module(
     "lambda/common/python/whiskey_common/images.py",
 )
 ROOT = Path(__file__).resolve().parents[2]
+requires_webp = pytest.mark.skipif(
+    not features.check("webp"), reason="Pillow built without WEBP support"
+)
 
 
 class TransactionCanceled(Exception):
@@ -245,6 +248,7 @@ def test_normalize_applies_orientation_and_strips_metadata():
         assert "icc_profile" not in result.info
 
 
+@requires_webp
 def test_normalize_flattens_transparent_png_and_accepts_webp():
     png = _image_bytes("PNG", size=(10, 10), mode="RGBA", color=(255, 0, 0, 0))
     normalized = images.normalize_image(png, max_bytes=1_572_864)
@@ -1195,7 +1199,10 @@ def test_upload_conflict_returns_503_instead_of_false_429(monkeypatch):
 
 @pytest.mark.parametrize(
     ("fmt", "content_type", "extension"),
-    [("PNG", "image/png", "png"), ("WEBP", "image/webp", "webp")],
+    [
+        ("PNG", "image/png", "png"),
+        pytest.param("WEBP", "image/webp", "webp", marks=requires_webp),
+    ],
 )
 def test_png_and_webp_finish_get_delete_flow(fmt, content_type, extension):
     upload_uuid = "12345678-1234-4234-8234-123456789abc"

--- a/tests/lambda/test_logger_integration.py
+++ b/tests/lambda/test_logger_integration.py
@@ -35,6 +35,17 @@ def test_response_serializes_decimal_and_sets_private_cache(monkeypatch):
     assert response["body"] == '{"rating": 4.5}'
     assert response["headers"]["Cache-Control"] == "private, no-store"
 
+    response_with_headers = responses.create_response(
+        200,
+        {"rating": Decimal("4.5")},
+        headers={"X-Test": "value"},
+        private=True,
+    )
+    assert response_with_headers["headers"] == {
+        "X-Test": "value",
+        "Cache-Control": "private, no-store",
+    }
+
 
 def test_clients_use_service_specific_endpoints_and_bounded_config(monkeypatch):
     monkeypatch.setenv("AWS_ENDPOINT_URL", "http://must-not-be-used")

--- a/tests/local_api/test_main.py
+++ b/tests/local_api/test_main.py
@@ -1,10 +1,12 @@
 """Contract checks for the local FastAPI-to-Lambda adapter."""
 
+import asyncio
 import os
 import subprocess
 import sys
 from pathlib import Path
 
+import httpx
 import pytest
 import yaml
 
@@ -56,13 +58,39 @@ def test_fastapi_routes_mirror_swagger_contract():
         if method.lower() in {"get", "post", "put", "delete", "patch"}
     }
     actual = {
-        (route.path, method)
+        (route.path.removesuffix("/"), method)
         for route in app.routes
         if route.path.startswith("/api/")
         for method in route.methods
         if method != "HEAD"
     }
     assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/whiskeys/",
+        "/api/whiskeys/search/",
+        "/api/whiskeys/search/suggest/",
+        "/api/whiskeys/suggest/",
+    ],
+)
+def test_whiskey_routes_accept_trailing_slash_without_redirect(monkeypatch, path):
+    from local_api import main
+
+    async def invoke(_request, _handler):
+        return main.Response(status_code=200)
+
+    monkeypatch.setattr(main, "invoke", invoke)
+
+    async def request():
+        transport = httpx.ASGITransport(app=main.app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+            return await client.get(path, follow_redirects=False)
+
+    response = asyncio.run(request())
+    assert response.status_code == 200
 
 
 def test_lambda_context_uses_a_deadline():


### PR DESCRIPTION
Four small, independent cleanups from an audit pass. No security defects were found in this repo — strict Cognito ID-token validation, CORS origin allowlisting, EXIF-stripping image normalization, presigned POST pinned to a single key, and DynamoDB conditional-expression quota counters all check out. This is the entire list of real findings.

| | change |
|---|---|
| **W1** | The two WEBP tests failed outright on any Pillow built without WEBP (local 11.0.0 on Python 3.14). The failure was in the *test helper*, not production code, and CI on 3.11 never saw it. Now conditional skips — the JPEG/PNG parameters still run for real. |
| **W2** | Removed `extract_user_id_from_token`, an alias with zero callers. |
| **W4** | `create_response` set `Cache-Control` twice for private responses. De-duplicated without behaviour change. |
| **W5** | The local adapter registered `/api/whiskeys/search` but `CLAUDE.md` documents `/api/whiskeys/search/` — the documented URL 404'd locally. |

## The two things worth reviewing carefully

**`create_response` is called on essentially every API response.** All four combinations of (headers supplied / omitted) × (`private` True / False) were verified behaviour-preserving, including the falsy-but-not-None `headers={}` case, which the old `headers or get_cors_headers(...)` expression handled in a specific way and which still falls through identically. A test was added for the supplied-headers + `private=True` branch — the one that would have regressed silently.

**W5 uses explicit route registration, not `redirect_slashes`.** A 307 on `/path/` → `/path` would break CORS from `http://localhost:3000`, which is the entire point of the local adapter. The route table was dumped to confirm all eight paths register and nothing is shadowed.

## Deliberately not done

`lambda/drink-logs/index.py`'s `lambda_handler` is a ~160-line if-chain with duplicated `RateLimitExceeded` / `TransientConflict` blocks and would benefit from a dispatch table. It fixes no defect and belongs in its own change, so it is excluded here.

## Verification

- `pytest tests` → **325 passed / 5 skipped / 0 failed** (baseline: 321 passed / 2 **failed** / 3 skipped)
- frontend `npm run lint` + `npm run typecheck` → clean
- `infra` jest → 46/46, untouched
- no dependencies added

🤖 Generated with [Claude Code](https://claude.com/claude-code)